### PR TITLE
Fixed repo fullName comparison with ashnazg

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -46,7 +46,7 @@ fetch("https://w3c.github.io/spec-dashboard/groups.json")
                 fetch("https://labs.w3.org/hatchery/repo-manager/api/repos")
                     .then(r => r.json())
                     .then(repoData => {
-                        const groupsWithAshNazg = repoData.map(r => r.fullName);
+                        const groupsWithAshNazg = repoData.map(r => r.fullName.toLowerCase());
                       errors.noashnazg = [...repos].map(r => r.toLowerCase()).filter(r => groupsWithAshNazg.indexOf(r) === -1);
                         return Promise.all([...repos].map(repofullname => {
                     return octo.repos('w3c/licenses').contents('WG-CONTRIBUTING.md').fetch().then(ghBlobToString).then(text => contributing = text)


### PR DESCRIPTION
Ash-Nazg is using mixed case repository fullname, eg "WebAudio/web-audio-api"
