### PR TITLE
Move the ESLint browser/node env declarations into *.js

### DIFF
--- a/graphql.js
+++ b/graphql.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+
 "use strict";
 
 const config = require("./config.json");

--- a/list-unconnected-contributors.js
+++ b/list-unconnected-contributors.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+
 const Octokat = require("octokat");
 const config = require("./config.json");
 const w3c = require('node-w3capi');

--- a/package.json
+++ b/package.json
@@ -18,9 +18,7 @@
   },
   "eslintConfig": {
     "env": {
-      "es6": true,
-      "browser": true,
-      "node": true
+      "es6": true
     },
     "extends": [
       "eslint:recommended"

--- a/report.js
+++ b/report.js
@@ -1,3 +1,5 @@
+/* eslint-env browser */
+
 let data;
 const errortypes = {
   "now3cjson": "No w3c.json file",

--- a/validate.js
+++ b/validate.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+
 "use strict";
 
 const fetch = require("node-fetch");

--- a/w3cLicenses.js
+++ b/w3cLicenses.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+
 "use strict";
 
 const graphql = require("./graphql.js");


### PR DESCRIPTION
This makes it very clear that report.js is not a node script.