### PR TITLE
Enable ESLint no-tabs rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
       "indent": [
         "error",
         2
-      ]
+      ],
+      "no-tabs": "error"
     },
     "parserOptions": {
       "ecmaVersion": 2019

--- a/validate.js
+++ b/validate.js
@@ -72,8 +72,8 @@ async function fetchLabelPage(org, repo, acc = [], cursor = null) {
               }
             }
             pageInfo {
-    	  	endCursor
-      	        hasNextPage
+              endCursor
+              hasNextPage
             }
          }
     }
@@ -114,8 +114,8 @@ async function fetchRepoPage(org, acc = [], cursor = null) {
               }
             }
             pageInfo {
-    	  	endCursor
-      	        hasNextPage
+              endCursor
+              hasNextPage
             }
           }
           defaultBranch: defaultBranchRef {


### PR DESCRIPTION
The indentation in validate.js assumed tab width 8.