### PR TITLE
Enable most ESLint whitespace rules

### DIFF
--- a/graphql.js
+++ b/graphql.js
@@ -9,7 +9,7 @@ const GH_API = "https://api.github.com/graphql";
 
 // use https://developer.github.com/v4/explorer/ to debug queries
 
-const GH_HEADERS =  {
+const GH_HEADERS = {
   "Accept": "application/vnd.github.v4.idl",
   "User-Agent": "graphql-github/0.1",
   "Content-Type": "application/json",

--- a/list-unconnected-contributors.js
+++ b/list-unconnected-contributors.js
@@ -8,7 +8,7 @@ const w3c = require('node-w3capi');
 const ashnazgusers = require('./ashnazg-users.json');
 
 w3c.apiKey = config.w3capikey;
-const octo = new Octokat({ token: config.ghToken });
+const octo = new Octokat({token: config.ghToken});
 
 if (!process.argv[2] || process.argv[2].indexOf('/') === -1) {
   console.error("Required: name of repo to check, e.g. w3c/webrtc-pc");

--- a/package.json
+++ b/package.json
@@ -33,7 +33,34 @@
         "error",
         2
       ],
-      "no-tabs": "error"
+      "array-bracket-spacing": "error",
+      "arrow-spacing": "error",
+      "block-spacing": "error",
+      "comma-spacing": "error",
+      "func-call-spacing": "error",
+      "generator-star-spacing": "error",
+      "key-spacing": "error",
+      "keyword-spacing": "error",
+      "no-multi-spaces": "error",
+      "no-tabs": "error",
+      "no-trailing-spaces": "error",
+      "object-curly-spacing": "error",
+      "rest-spread-spacing": "error",
+      "semi-spacing": "error",
+      "space-before-blocks": "error",
+      "space-before-function-paren": [
+        "error",
+        {
+          "anonymous": "never",
+          "named": "never",
+          "asyncArrow": "always"
+        }
+      ],
+      "space-in-parens": "error",
+      "space-infix-ops": "error",
+      "space-unary-ops": "error",
+      "template-curly-spacing": "error",
+      "yield-star-spacing": "error"
     },
     "parserOptions": {
       "ecmaVersion": 2019

--- a/report.js
+++ b/report.js
@@ -18,7 +18,7 @@ const errortypes = {
   "invalidlicense": "Invalid LICENSE.md file",
   "noreadme": "No README.md file"
 };
-const defaultReport = ["now3cjson", "inconsistengroups", "invalidw3cjson", "incompletew3cjson", "noashnazg", "inconsistentstatus", "unprotectedbranch","missingashnazghook"];
+const defaultReport = ["now3cjson", "inconsistengroups", "invalidw3cjson", "incompletew3cjson", "noashnazg", "inconsistentstatus", "unprotectedbranch", "missingashnazghook"];
 
 // from https://stackoverflow.com/questions/10970078/modifying-a-query-string-without-reloading-the-page
 function insertUrlParam(key, value) {
@@ -82,14 +82,14 @@ const writeErrorEntry = (name, list, details) => {
 
 fetch("report.json")
   .then(r => r.json())
-  .then(fetcheddata => { data = fetcheddata; writeReport();} );
+  .then(fetcheddata => { data = fetcheddata; writeReport(); });
 
 
 function writeReport() {
   if (!data) return;
   let mentionedRepos = new Set();
   const groupFilter = gid => getUrlParam("grouptype") ? (groups[gid].type || '').replace(' ', '') === getUrlParam("grouptype") : true;
-  const errorFilter = new Set((getUrlParam("filter") || defaultReport.join(',')).split(",").filter(e => e !==''));
+  const errorFilter = new Set((getUrlParam("filter") || defaultReport.join(',')).split(",").filter(e => e !== ''));
 
   const report = document.getElementById('report');
   report.innerHTML = '';
@@ -97,7 +97,7 @@ function writeReport() {
   stats.textContent = `${data.repos.filter(r => r.owner.login === 'w3c' && !r.isArchived).length} active repos in the w3c github organization; overall, ${Object.values(data.groups).filter(g => g.type === 'working group').reduce((acc, g) => acc + g.repos.length, 0)} known repos associated with Working Groups, ${Object.values(data.groups).filter(g => g.type === 'community group').reduce((acc, g) => acc + g.repos.length, 0)} associated with Community Groups`;
   report.appendChild(stats);
   const groups = data.groups;
-  Object.keys(groups).sort((a,b) => groups[a].name.localeCompare(groups[b].name))
+  Object.keys(groups).sort((a, b) => groups[a].name.localeCompare(groups[b].name))
     .forEach(groupId => {
       const section = document.createElement('section');
       const title = document.createElement('h2');

--- a/test/graphql.js
+++ b/test/graphql.js
@@ -3,13 +3,13 @@
 'use strict';
 
 const assert = require('assert');
-const proxyquire =  require('proxyquire');
+const proxyquire = require('proxyquire');
 const sinon = require('sinon');
 
 const GH_API = 'https://api.github.com/graphql';
 
 describe('graphql', () => {
-  const mockConfig = { ghToken: 'mock-token' };
+  const mockConfig = {ghToken: 'mock-token'};
 
   it('happy path', async () => {
     const fakeFetch = sinon.fake.resolves({

--- a/test/w3cLicenses.js
+++ b/test/w3cLicenses.js
@@ -3,7 +3,7 @@
 'use strict';
 
 const assert = require('assert');
-const proxyquire =  require('proxyquire');
+const proxyquire = require('proxyquire');
 const sinon = require('sinon');
 
 describe('w3cLicenses', () => {

--- a/validate.js
+++ b/validate.js
@@ -14,10 +14,10 @@ const config = require("./config.json");
 const ashnazgHookUrls = ["https://labs.w3.org/hatchery/repo-manager/api/hook", "https://labs.w3.org/repo-manager/api/hook"];
 
 w3c.apiKey = config.w3capikey;
-const octo = new Octokat({ token: config.ghToken });
+const octo = new Octokat({token: config.ghToken});
 
 const orgs = ["w3c", "WebAudio", "immersive-web", "webassembly", "w3ctag", "WICG", "w3cping"];
-const errors = {"inconsistentgroups": [], "now3cjson":[], "invalidw3cjson": [], "illformedw3cjson":[], "incompletew3cjson":[], "nocontributing":[], "invalidcontributing": [], "nolicense": [], "nocodeofconduct": [], "invalidlicense": [], "noreadme": [],  "noashnazg": [], "inconsistentstatus": [], "unprotectedbranch": [], "missingashnazghook": [], "duplicateashnazghooks": []};
+const errors = {"inconsistentgroups": [], "now3cjson": [], "invalidw3cjson": [], "illformedw3cjson": [], "incompletew3cjson": [], "nocontributing": [], "invalidcontributing": [], "nolicense": [], "nocodeofconduct": [], "invalidlicense": [], "noreadme": [], "noashnazg": [], "inconsistentstatus": [], "unprotectedbranch": [], "missingashnazghook": [], "duplicateashnazghooks": []};
 
 // for some repos, having the w3c.json administrative file is felt as awkward
 // we hard-code their equivalent here
@@ -90,8 +90,8 @@ async function fetchLabelPage(org, repo, acc = [], cursor = null) {
       return {"repo": {"owner": org, "name": repo}, "labels": data.map(e => e.node)};
     }
   } else {
-    console.error("Fetching label for " + repo + " at cursor " + cursor + " failed with " + JSON.stringify(res)+ ", not retrying");
-    return {"repo": {"owner": org, "name": repo}, "labels": acc.map(e => e.node) };
+    console.error("Fetching label for " + repo + " at cursor " + cursor + " failed with " + JSON.stringify(res) + ", not retrying");
+    return {"repo": {"owner": org, "name": repo}, "labels": acc.map(e => e.node)};
     //return fetchLabelPage(org, repo, acc, cursor);
   }
 }
@@ -207,7 +207,7 @@ async function validate() {
   async function sequenced(index) {
     if (index === orgs.length) return [];
     let repos = await fetchRepoPage(orgs[index]);
-    let next = await sequenced(index+1);
+    let next = await sequenced(index + 1);
     return repos.concat(next);
   }
   const allrepos = await sequenced(0);
@@ -231,16 +231,16 @@ async function validate() {
       errors.nolicense.push(fullName(r));
     } else {
       if (!mdMatch(r.license.text, license) && !mdMatch(r.license.text, licenseSw))
-        errors.invalidlicense.push({ repo: fullName(r), error: "doesn't match SW or DOC license", license: r.license.text });
+        errors.invalidlicense.push({repo: fullName(r), error: "doesn't match SW or DOC license", license: r.license.text});
     }
     if (!r.contributing || !r.contributing.text) {
       errors.nocontributing.push(fullName(r));
     } else {
       if (!mdMatch(r.contributing.text, contributing) && !mdMatch(r.contributing.text, contributingSw))
-        errors.invalidcontributing.push({ repo: fullName(r), error: "doesn't match SW or DOC contributing", contributing: r.contributing.text });
+        errors.invalidcontributing.push({repo: fullName(r), error: "doesn't match SW or DOC contributing", contributing: r.contributing.text});
     }
     let shouldBeRepoManaged = false;
-    let hasRecTrack = {ashnazg: null, repotype:null, tr: null}; // TODO detect conflicting information (repo-type vs ash-nazg vs TR doc)
+    let hasRecTrack = {ashnazg: null, repotype: null, tr: null}; // TODO detect conflicting information (repo-type vs ash-nazg vs TR doc)
 
     let groups = [];
     // is the repo associated with a CG in the CG monitor?
@@ -280,9 +280,9 @@ async function validate() {
       r.w3c = conf;
       // TODO: replace with JSON schema?
       if (!conf["repo-type"]) {
-        errors.incompletew3cjson.push({repo: fullName(r), error: "repo-type" + (Object.values(hasRecTrack).every(x => x === null) ? " (unknown)" : (hasRecTrack.tr || hasRecTrack.ashnazg ? " (rec-track)" : " (not rec-track)")) });
+        errors.incompletew3cjson.push({repo: fullName(r), error: "repo-type" + (Object.values(hasRecTrack).every(x => x === null) ? " (unknown)" : (hasRecTrack.tr || hasRecTrack.ashnazg ? " (rec-track)" : " (not rec-track)"))});
       } else {
-        hasRecTrack.repotype = arrayify(conf["repo-type"]).includes('rec-track') ;
+        hasRecTrack.repotype = arrayify(conf["repo-type"]).includes('rec-track');
 
         const unknownTypes = arrayify(conf['repo-type']).filter(t => !validRepoTypes.includes(t));
         if (unknownTypes.length) {
@@ -347,7 +347,7 @@ async function validate() {
     groups.forEach(gid => {
       if (!groupRepos[gid])
         groupRepos[gid] = [];
-      groupRepos[gid].push({ name: r.name, fullName: fullName(r), hasRecTrack: recTrackStatus });
+      groupRepos[gid].push({name: r.name, fullName: fullName(r), hasRecTrack: recTrackStatus});
     });
   });
 
@@ -390,7 +390,7 @@ async function validate() {
   results.timestamp = new Date();
   results.repos = allrepos;
   results.groups = w3cgroups.filter(g => allgroups.has(g.id)).reduce((acc, group) => {
-    acc[group.id] = {...group, repos: groupRepos[group.id] };
+    acc[group.id] = {...group, repos: groupRepos[group.id]};
     return acc;
   }, {});
   console.log(JSON.stringify(results, null, 2));


### PR DESCRIPTION
These are most of the whitespace-related rules in
https://eslint.org/docs/rules/ not already in eslint:recommended.

These can all be fixed with the `--fix` command line option, and
produce whitespace differences only.