### PR TITLE
Remove broken retry logic in w3cLicenses.js

### DIFF
--- a/w3cLicenses.js
+++ b/w3cLicenses.js
@@ -7,8 +7,7 @@ const graphql = require("./graphql.js");
 
 // Set up the config of this repository
 async function licenses() {
-  async function query() {
-    let res = graphql(`
+  let res = await graphql(`
   query {
     repository(owner:"w3c",name:"licenses") {
       contributing: object(expression: "HEAD:WG-CONTRIBUTING.md") {
@@ -40,11 +39,6 @@ async function licenses() {
   }
   }
   `);
-    if (res) return res;
-    console.error('Query for w3c/licenses failed, retrying');
-    return query();
-  }
-  let res = await query();
   res = res.repository;
 
   if (res.contributing) {


### PR DESCRIPTION
Because `graphql` is an async function it will always return a
promise, meaning that `res` would always be truthy.

A proper retry mechanism would have to handle promise rejection, but
instead pare it down to what the current behavior actually was.