### PR TITLE
Enforce consistent brace style for blocks

### DIFF
--- a/lib/graphql.js
+++ b/lib/graphql.js
@@ -28,7 +28,9 @@ async function graphql(query) {
   if (obj.errors) {
     const ghErr = obj.errors[0]; // just return the first error
     const err = new Error(ghErr.message, "unknown", -1);
-    if (ghErr.type) err.type = ghErr.type;
+    if (ghErr.type) {
+      err.type = ghErr.type;
+    }
     err.all = obj.errors;
     throw err;
   }

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -56,14 +56,16 @@ function validateRepo(r, licenses, repoData, cgData, repoMap) {
   if (!r.license || !r.license.text) {
     reportError('nolicense');
   } else {
-    if (!mdMatch(r.license.text, license) && !mdMatch(r.license.text, licenseSw))
+    if (!mdMatch(r.license.text, license) && !mdMatch(r.license.text, licenseSw)) {
       reportError('invalidlicense', {error: "doesn't match SW or DOC license", license: r.license.text});
+    }
   }
   if (!r.contributing || !r.contributing.text) {
     reportError('nocontributing');
   } else {
-    if (!mdMatch(r.contributing.text, contributing) && !mdMatch(r.contributing.text, contributingSw))
+    if (!mdMatch(r.contributing.text, contributing) && !mdMatch(r.contributing.text, contributingSw)) {
       reportError('invalidcontributing', {error: "doesn't match SW or DOC contributing", contributing: r.contributing.text});
+    }
   }
   let shouldBeRepoManaged = false;
   const hasRecTrack = {ashnazg: null, repotype: null, tr: null}; // TODO detect conflicting information (repo-type vs ash-nazg vs TR doc)
@@ -76,8 +78,9 @@ function validateRepo(r, licenses, repoData, cgData, repoMap) {
   // is the repo associated with a WG in the spec dashboard?
   const wgRepo = repoMap[fullName(r)];
   const audioWgRepo = r.owner.login === 'WebAudio' ? {id: 46884} : null;
-  if (wgRepo)
+  if (wgRepo) {
     hasRecTrack.tr = wgRepo.some(x => x.recTrack);
+  }
 
   const ashRepo = repoData.find(x => x.owner.toLowerCase() === r.owner.login.toLowerCase() && x.name.toLowerCase() === r.name.toLowerCase());
   if (ashRepo) {
@@ -185,10 +188,12 @@ function validateAshHooks(hooks) {
   // of report.json. TODO: change this to null, or add error details.
   const errors = [];
   const ashHooks = hooks.filter(h => ashnazgHookUrls.includes(h.config.url) && h.config.contentType === "json" && h.config.insecureSsl === "0" && h.config.secret !== "");
-  if (ashHooks.length === 0)
+  if (ashHooks.length === 0) {
     errors.push(['missingashnazghook', {}]);
-  if (ashHooks.length > 1)
+  }
+  if (ashHooks.length > 1) {
     errors.push(['duplicateashnazghooks', {}]);
+  }
   return errors;
 }
 

--- a/list-unconnected-contributors.js
+++ b/list-unconnected-contributors.js
@@ -24,10 +24,11 @@ octo.repos(selectedrepo).contributors.fetch().then(contributors => {
         if (err) {
           if (err.status === 404) {
             // is the user known in ahsnazg local db?
-            if (ashnazgusers.indexOf(contributor.id) !== -1)
+            if (ashnazgusers.indexOf(contributor.id) !== -1) {
               return res(null);
-            else
+            } else {
               return res({login: contributor.login, contributions: contributor.contributions});
+            }
           } else {
             return rej(err);
           }

--- a/package.json
+++ b/package.json
@@ -29,16 +29,18 @@
       "eslint:recommended"
     ],
     "rules": {
+      "array-bracket-spacing": "error",
+      "arrow-spacing": "error",
+      "block-spacing": "error",
+      "brace-style": "error",
+      "comma-spacing": "error",
+      "curly": "error",
+      "func-call-spacing": "error",
+      "generator-star-spacing": "error",
       "indent": [
         "error",
         2
       ],
-      "array-bracket-spacing": "error",
-      "arrow-spacing": "error",
-      "block-spacing": "error",
-      "comma-spacing": "error",
-      "func-call-spacing": "error",
-      "generator-star-spacing": "error",
       "key-spacing": "error",
       "keyword-spacing": "error",
       "no-multi-spaces": "error",

--- a/report.js
+++ b/report.js
@@ -1,6 +1,5 @@
 /* eslint-env browser */
 
-let data;
 const errortypes = {
   "now3cjson": "No w3c.json file",
   "invalidw3cjson": "Invalid data in w3c.json",
@@ -74,19 +73,13 @@ const writeErrorEntry = (name, list, details) => {
   link.href = 'https://github.com/' + name;
   link.appendChild(document.createTextNode(name));
   li.appendChild(link);
-  if (details)
+  if (details) {
     li.appendChild(document.createTextNode(': ' + details));
+  }
   list.appendChild(li);
 };
 
-
-fetch("report.json")
-  .then(r => r.json())
-  .then(fetcheddata => { data = fetcheddata; writeReport(); });
-
-
-function writeReport() {
-  if (!data) return;
+function writeReport(data) {
   const mentionedRepos = new Set();
   const groupFilter = gid => getUrlParam("grouptype") ? (groups[gid].type || '').replace(' ', '') === getUrlParam("grouptype") : true;
   const errorFilter = new Set((getUrlParam("filter") || defaultReport.join(',')).split(",").filter(e => e !== ''));
@@ -102,8 +95,9 @@ function writeReport() {
       const section = document.createElement('section');
       const title = document.createElement('h2');
       title.appendChild(document.createTextNode(groups[groupId].name));
-      if (groupFilter(groupId))
+      if (groupFilter(groupId)) {
         section.appendChild(title);
+      }
       if (groups[groupId].type === "working group" && !groups[groupId].repos.some(r => r.hasRecTrack)) {
         const p = document.createElement('p');
         p.appendChild(document.createTextNode('No identified repo for rec-track spec.'));
@@ -127,8 +121,9 @@ function writeReport() {
 
               });
               errsection.appendChild(list);
-              if (groupFilter(groupId))
+              if (groupFilter(groupId)) {
                 section.appendChild(errsection);
+              }
             }
           });
       }
@@ -152,3 +147,6 @@ function writeReport() {
   report.appendChild(section);
 }
 
+fetch("report.json")
+  .then(r => r.json())
+  .then(writeReport);

--- a/test/graphql.js
+++ b/test/graphql.js
@@ -13,7 +13,9 @@ describe('graphql', () => {
 
   it('happy path', async () => {
     const fakeFetch = sinon.fake.resolves({
-      async json() { return {data: 'mock response'} }
+      async json() {
+        return {data: 'mock response'}
+      }
     });
     const graphql = proxyquire('../lib/graphql.js', {
       '../config.json': mockConfig,
@@ -31,7 +33,9 @@ describe('graphql', () => {
 
   it('API error', async () => {
     const fakeFetch = sinon.fake.resolves({
-      async json() { return {errors: [{message: 'API error'}]} }
+      async json() {
+        return {errors: [{message: 'API error'}]}
+      }
     });
     const graphql = proxyquire('../lib/graphql.js', {
       '../config.json': mockConfig,
@@ -48,7 +52,9 @@ describe('graphql', () => {
       type: 'error',
       status: 500,
       ok: false,
-      async json() { return {data: 'valid response'} }
+      async json() {
+        return {data: 'valid response'}
+      }
     });
     const graphql = proxyquire('../lib/graphql.js', {
       '../config.json': mockConfig,

--- a/validate.js
+++ b/validate.js
@@ -163,7 +163,9 @@ async function validate() {
   const licenses = await w3cLicenses();
 
   async function sequenced(index) {
-    if (index === orgs.length) return [];
+    if (index === orgs.length) {
+      return [];
+    }
     const repos = await fetchRepoPage(orgs[index]);
     const next = await sequenced(index + 1);
     return repos.concat(next);
@@ -206,8 +208,9 @@ async function validate() {
     pushErrors(r, errors);
     for (const gid of groups) {
       allgroups.add(gid);
-      if (!groupRepos[gid])
+      if (!groupRepos[gid]) {
         groupRepos[gid] = [];
+      }
       groupRepos[gid].push({
         name: r.name,
         fullName: fullName(r),


### PR DESCRIPTION
This is mainly to force branches onto new lines (see lib/graphql.js)
so that missing coverage shows up as missing line coverage, which is
easier to reason about than branch or statement coverage.

All changes were made by `eslint --fix` except report.js where the
code was instead simplified to remove the offending code entirely.