### PR TITLE
Improve test coverage for test/validator.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "scripts": {
     "lint": "eslint .",
-    "test": "nyc --all mocha"
+    "test": "nyc mocha"
   },
   "dependencies": {
     "node-fetch": "^1.6.3",
@@ -68,5 +68,12 @@
     "parserOptions": {
       "ecmaVersion": 2019
     }
+  },
+  "nyc": {
+    "all": true,
+    "include": ["lib/**"],
+    "check-coverage": true,
+    "per-file": true,
+    "lines": 100
   }
 }

--- a/test/validator.js
+++ b/test/validator.js
@@ -13,7 +13,7 @@ function filter(errors, types) {
 }
 
 describe('validateRepo', () => {
-  it('empty repo', async () => {
+  it('empty repo', () => {
     const repo = {
       owner: {login: 'foo'},
       name: 'bar',
@@ -40,7 +40,67 @@ describe('validateRepo', () => {
     assert.deepStrictEqual(groups, []);
   });
 
-  it('minimal compliant note repo', async () => {
+  it('invalid contributing and license', () => {
+    const repo = {
+      owner: {login: 'foo'},
+      name: 'bar',
+      contributing: {text: 'invalid CONTRIBUTING.md content'},
+      license: {text: 'invalid LICENSE.md content'},
+    };
+    const licenses = {
+      license: 'mock LICENSE.md content',
+      licenseSw: 'mock LICENSE-SW.md content',
+      contributing: 'mock CONTRIBUTING.md content',
+      contributingSw: 'mock CONTRIBUTING-SW.md content',
+    };
+    const repoData = [];
+    const cgData = {data: []};
+    const repoMap = {};
+    const {errors} = validateRepo(repo, licenses, repoData, cgData, repoMap);
+    const types = ['invalidcontributing', 'invalidlicense']
+    assert.deepStrictEqual(filter(errors, types), [
+      ['invalidlicense', {
+        license: 'invalid LICENSE.md content',
+        error: "doesn't match SW or DOC license",
+      }],
+      ['invalidcontributing', {
+        contributing: 'invalid CONTRIBUTING.md content',
+        error: "doesn't match SW or DOC contributing"
+      }],
+    ]);
+  });
+
+  it('pr-preview config is extracted', () => {
+    const repo = {
+      owner: {login: 'foo'},
+      name: 'bar',
+      prpreviewjson: {text: '{"aKey":"someValue"}'},
+    };
+    const licenses = {};
+    const repoData = [];
+    const cgData = {data: []};
+    const repoMap = {};
+    validateRepo(repo, licenses, repoData, cgData, repoMap);
+    assert.deepStrictEqual(repo.prpreview, {aKey: 'someValue'});
+  });
+
+  it('hardcoded repo data', () => {
+    const repo = {
+      owner: {login: 'w3c'},
+      name: 'markup-validator',
+    };
+    const licenses = {};
+    const repoData = [];
+    const cgData = {data: []};
+    const repoMap = {};
+    validateRepo(repo, licenses, repoData, cgData, repoMap);
+    assert.deepStrictEqual(repo.w3c, {
+      contacts: 'sideshowbarker',
+      'repo-type': 'tool',
+    });
+  });
+
+  it('minimal compliant note repo', () => {
     const repo = {
       owner: {login: 'foo'},
       name: 'bar',
@@ -73,37 +133,7 @@ describe('validateRepo', () => {
     assert.deepStrictEqual(groups, [42]);
   });
 
-  it('invalid contributing and license', async () => {
-    const repo = {
-      owner: {login: 'foo'},
-      name: 'bar',
-      contributing: {text: 'invalid CONTRIBUTING.md content'},
-      license: {text: 'invalid LICENSE.md content'},
-    };
-    const licenses = {
-      license: 'mock LICENSE.md content',
-      licenseSw: 'mock LICENSE-SW.md content',
-      contributing: 'mock CONTRIBUTING.md content',
-      contributingSw: 'mock CONTRIBUTING-SW.md content',
-    };
-    const repoData = [];
-    const cgData = {data: []};
-    const repoMap = {};
-    const {errors} = validateRepo(repo, licenses, repoData, cgData, repoMap);
-    const types = ['invalidcontributing', 'invalidlicense']
-    assert.deepStrictEqual(filter(errors, types), [
-      ['invalidlicense', {
-        license: 'invalid LICENSE.md content',
-        error: "doesn't match SW or DOC license",
-      }],
-      ['invalidcontributing', {
-        contributing: 'invalid CONTRIBUTING.md content',
-        error: "doesn't match SW or DOC contributing"
-      }],
-    ]);
-  });
-
-  it('minimal compliant rec-track repo', async () => {
+  it('minimal compliant WG repo', () => {
     const repo = {
       owner: {login: 'foo'},
       name: 'bar',
@@ -113,7 +143,7 @@ describe('validateRepo', () => {
       license: {text: 'mock LICENSE.md content'},
       w3cjson: {text: JSON.stringify({
         contacts: [],
-        group: ['42'],
+        group: ['43'],
         'repo-type': 'rec-track',
       })},
       branchProtectionRules: {
@@ -131,7 +161,7 @@ describe('validateRepo', () => {
       name: 'bar',
       groups: [{
         groupType: 'WG',
-        w3cid: '42',
+        w3cid: '43',
       }],
     }];
     const cgData = {data: []};
@@ -147,10 +177,124 @@ describe('validateRepo', () => {
     assert.deepStrictEqual(errors, []);
     assert.strictEqual(isAshRepo, true);
     assert.strictEqual(hasRecTrack, true);
-    assert.deepStrictEqual(groups, [42]);
+    assert.deepStrictEqual(groups, [43]);
   });
 
-  it('missing ashnazg and branch protection', async () => {
+  it('groups for WG repo sans w3c.json', () => {
+    const repo = {
+      owner: {login: 'foo'},
+      name: 'bar',
+    };
+    const licenses = {};
+    const repoData = [];
+    const cgData = {data: []};
+    const repoMap = {
+      'foo/bar': [{group: 44}],
+    };
+    const {groups} = validateRepo(repo, licenses, repoData, cgData, repoMap);
+    assert.deepStrictEqual(groups, [44]);
+  });
+
+  it('groups for CG repo sans w3c.json', () => {
+    const repo = {
+      owner: {login: 'foo'},
+      name: 'bar',
+    };
+    const licenses = {};
+    const repoData = [];
+    const cgData = {data: [{
+      id: 45,
+      repositories: ['https://github.com/foo/bar'],
+    }]};
+    const repoMap = {};
+    const {groups} = validateRepo(repo, licenses, repoData, cgData, repoMap);
+    // Note: id from `cgData` clobbers id from `repoData`
+    assert.deepStrictEqual(groups, [45]);
+  });
+
+  it('groups for WICG repo sans w3c.json', () => {
+    const repo = {
+      owner: {login: 'WICG'},
+      name: 'bar',
+    };
+    const licenses = {};
+    const repoData = [];
+    const cgData = {data: []};
+    const repoMap = {};
+    const {groups} = validateRepo(repo, licenses, repoData, cgData, repoMap);
+    // Note: hardcoded WICG group id clobbers id from `repoData`
+    assert.deepStrictEqual(groups, [80485]);
+  });
+
+  it('groups for WebAudio WG repo sans w3c.json', () => {
+    const repo = {
+      owner: {login: 'WebAudio'},
+      name: 'bar',
+    };
+    const licenses = {};
+    const repoData = [];
+    const cgData = {data: []};
+    const repoMap = {};
+    const {groups} = validateRepo(repo, licenses, repoData, cgData, repoMap);
+    assert.deepStrictEqual(groups, [46884]);
+  });
+
+  it('ill-formed w3c.json', () => {
+    const repo = {
+      owner: {login: 'foo'},
+      name: 'bar',
+      w3cjson: {text: 'ill-formed JSON'},
+    };
+    const licenses = {};
+    const repoData = [];
+    const cgData = {data: []};
+    const repoMap = {};
+    const {errors} = validateRepo(repo, licenses, repoData, cgData, repoMap);
+    assert.deepStrictEqual(filter(errors, ['illformedw3cjson']), [
+      ['illformedw3cjson', null],
+    ]);
+  });
+
+  it('empty w3c.json', () => {
+    const repo = {
+      owner: {login: 'foo'},
+      name: 'bar',
+      w3cjson: {text: '{}'},
+    };
+    const licenses = {};
+    const repoData = [];
+    const cgData = {data: []};
+    const repoMap = {};
+    const {errors} = validateRepo(repo, licenses, repoData, cgData, repoMap);
+    assert.deepStrictEqual(filter(errors, ['incompletew3cjson']), [
+      ['incompletew3cjson', {error: 'repo-type (unknown)'}],
+      ['incompletew3cjson', {error: 'contacts'}],
+    ]);
+  });
+
+  it('w3c.json invalid type and contacts', () => {
+    const repo = {
+      owner: {login: 'foo'},
+      name: 'bar',
+      w3cjson: {text: JSON.stringify({
+        contacts: [123],
+        'repo-type': 'foo',
+      })},
+    };
+    const licenses = {};
+    const repoData = [];
+    const cgData = {data: []};
+    const repoMap = {
+      'foo/bar': [{recTrack: true}],
+    };
+    const {errors} = validateRepo(repo, licenses, repoData, cgData, repoMap);
+    assert.deepStrictEqual(filter(errors, ['invalidw3cjson']), [
+      ['invalidw3cjson', {error: 'unknown types: ["foo"]'}],
+      ['invalidw3cjson', {error: 'invalid contacts: [123]'}],
+    ]);
+  });
+
+  it('missing ashnazg and branch protection', () => {
     const repo = {
       owner: {login: 'foo'},
       name: 'bar',
@@ -171,16 +315,62 @@ describe('validateRepo', () => {
       ['unprotectedbranch', {error: 'No protected branch'}],
     ]);
   });
+
+  it('inconsistent status in repo manager', () => {
+    const repo = {
+      owner: {login: 'foo'},
+      name: 'bar',
+      w3cjson: {text: JSON.stringify({'repo-type': 'rec-track'})},
+    };
+    const licenses = {};
+    const repoData = [{
+      owner: 'foo',
+      name: 'bar',
+      groups: [{groupType: 'CG'}],
+    }];
+    const cgData = {data: []};
+    const repoMap = {
+      'foo/bar': [{recTrack: true}],
+    };
+    const {errors} = validateRepo(repo, licenses, repoData, cgData, repoMap);
+    assert.deepStrictEqual(filter(errors, ['inconsistentstatus']), [
+      ['inconsistentstatus', {error: 'TR document: true, vs repo manager: false'}],
+      ['inconsistentstatus', {error: 'repo: true, vs repo manager: false'}],
+    ]);
+  });
+
+  it('inconsistent status in repo map', () => {
+    const repo = {
+      owner: {login: 'foo'},
+      name: 'bar',
+      w3cjson: {text: JSON.stringify({'repo-type': 'rec-track'})},
+    };
+    const licenses = {};
+    const repoData = [{
+      owner: 'foo',
+      name: 'bar',
+      groups: [{groupType: 'WG'}],
+    }];
+    const cgData = {data: []};
+    const repoMap = {
+      'foo/bar': [{recTrack: false}],
+    };
+    const {errors} = validateRepo(repo, licenses, repoData, cgData, repoMap);
+    assert.deepStrictEqual(filter(errors, ['inconsistentstatus']), [
+      ['inconsistentstatus', {error: 'TR document: false, vs repo: true'}],
+      ['inconsistentstatus', {error: 'TR document: false, vs repo manager: true'}],
+    ]);
+  });
 });
 
 describe('validateAshHooks', () => {
-  it('no hooks', async () => {
+  it('no hooks', () => {
     const hooks = [];
     const errors = validateAshHooks(hooks);
     assert.deepStrictEqual(errors, [['missingashnazghook', {}]]);
   });
 
-  it('one hook', async () => {
+  it('one hook', () => {
     const hooks = [{
       config: {
         url: 'https://labs.w3.org/repo-manager/api/hook',
@@ -193,7 +383,7 @@ describe('validateAshHooks', () => {
     assert.deepStrictEqual(errors, []);
   });
 
-  it('duplicate hooks', async () => {
+  it('duplicate hooks', () => {
     const hooks = [{
       config: {
         url: 'https://labs.w3.org/hatchery/repo-manager/api/hook',


### PR DESCRIPTION
This brings the line coverage to 100, so change the nyc configuration
to require it. It will still be possible to have exceptions:
https://github.com/istanbuljs/nyc#parsing-hints-ignoring-lines