### PR TITLE
Fix a misnested `.find(...)` expression for CG lookup

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -70,14 +70,15 @@ function validateRepo(r, licenses, repoData, cgData, repoMap) {
   let shouldBeRepoManaged = false;
   const hasRecTrack = {ashnazg: null, repotype: null, tr: null}; // TODO detect conflicting information (repo-type vs ash-nazg vs TR doc)
 
-  let groups = [];
   // is the repo associated with a CG in the CG monitor?
-  const cgRepo = cgData.data.find(cg => cg.repositories.includes('https://github.com/' + fullName(r) || cg.repositories.includes('https://github.com/' + fullName(r) + '/'))) ||
-        // is the repo in WICG space?
-        (r.owner.login === 'WICG' ? {id: 80485} : null);
+  const cg = cgData.data.find(cg => {
+    return cg.repositories.includes('https://github.com/' + fullName(r)) ||
+           cg.repositories.includes('https://github.com/' + fullName(r) + '/');
+  });
+
   // is the repo associated with a WG in the spec dashboard?
   const wgRepo = repoMap[fullName(r)];
-  const audioWgRepo = r.owner.login === 'WebAudio' ? {id: 46884} : null;
+
   if (wgRepo) {
     hasRecTrack.tr = wgRepo.some(x => x.recTrack);
   }
@@ -104,6 +105,8 @@ function validateRepo(r, licenses, repoData, cgData, repoMap) {
   } else if (hardcodedRepoData[fullName(r)]) {
     conf = hardcodedRepoData[fullName(r)];
   }
+
+  let groups = [];
   if (conf) {
     r.w3c = conf;
     // TODO: replace with JSON schema?
@@ -131,14 +134,16 @@ function validateRepo(r, licenses, repoData, cgData, repoMap) {
       }
     }
   } else {
-    if (cgRepo) {
-      groups = [cgRepo.id];
+    if (cg) {
+      groups = [cg.id];
+    } else if (r.owner.login === 'WICG') {
+      groups = [80485];
     }
     if (wgRepo && wgRepo.length) {
       groups = groups.concat(wgRepo.map(x => x.group));
     }
-    if (audioWgRepo) {
-      groups.push(audioWgRepo.id);
+    if (r.owner.login === 'WebAudio') {
+      groups.push(46884);
     }
     reportError('now3cjson');
   }

--- a/test/validator.js
+++ b/test/validator.js
@@ -204,11 +204,10 @@ describe('validateRepo', () => {
     const repoData = [];
     const cgData = {data: [{
       id: 45,
-      repositories: ['https://github.com/foo/bar'],
+      repositories: ['https://github.com/foo/bar/'],
     }]};
     const repoMap = {};
     const {groups} = validateRepo(repo, licenses, repoData, cgData, repoMap);
-    // Note: id from `cgData` clobbers id from `repoData`
     assert.deepStrictEqual(groups, [45]);
   });
 
@@ -222,7 +221,6 @@ describe('validateRepo', () => {
     const cgData = {data: []};
     const repoMap = {};
     const {groups} = validateRepo(repo, licenses, repoData, cgData, repoMap);
-    // Note: hardcoded WICG group id clobbers id from `repoData`
     assert.deepStrictEqual(groups, [80485]);
   });
 


### PR DESCRIPTION
The misnesting caused the case with a trailing slash to not work, so
update the test such that it would have failed without this fix.

Also slightly reorganize lib/validator.js by initializing this closer
to where they are used. This makes it clear that the clobbering
comments were wrong, `groups` is actually just written in both the
if-branch and the else-branch.