### PR TITLE
Extract lookup of repo/CG/WG data from APIs to validate.js

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -39,7 +39,8 @@ const mdMatch = (md, ref) => nlToSpace(httpToHttps(md.toLowerCase())).indexOf(nl
 
 const fullName = r => r.owner.login + '/' + r.name;
 
-function validateRepo(r, licenses, repoData, cgData, repoMap) {
+// Also potentially sets `r.prpreview` and `r.w3c`.
+function validateRepo(r, data, licenses) {
   const {contributing, contributingSw, license, licenseSw} = licenses;
 
   const errors = [];
@@ -70,20 +71,12 @@ function validateRepo(r, licenses, repoData, cgData, repoMap) {
   let shouldBeRepoManaged = false;
   const hasRecTrack = {ashnazg: null, repotype: null, tr: null}; // TODO detect conflicting information (repo-type vs ash-nazg vs TR doc)
 
-  // is the repo associated with a CG in the CG monitor?
-  const cg = cgData.data.find(cg => {
-    return cg.repositories.includes('https://github.com/' + fullName(r)) ||
-           cg.repositories.includes('https://github.com/' + fullName(r) + '/');
-  });
-
-  // is the repo associated with a WG in the spec dashboard?
-  const wgRepo = repoMap[fullName(r)];
-
-  if (wgRepo) {
-    hasRecTrack.tr = wgRepo.some(x => x.recTrack);
+  const {specs} = data;
+  if (specs && specs.length) {
+    hasRecTrack.tr = specs.some(s => s.recTrack);
   }
 
-  const ashRepo = repoData.find(x => x.owner.toLowerCase() === r.owner.login.toLowerCase() && x.name.toLowerCase() === r.name.toLowerCase());
+  const {ashRepo} = data;
   if (ashRepo) {
     hasRecTrack.ashnazg = ashRepo.groups.some(g => g.groupType === "WG");
   }
@@ -123,6 +116,7 @@ function validateRepo(r, licenses, repoData, cgData, repoMap) {
     if (!conf.group && ["rec-track", "note", "cg-report"].includes(conf["repo-type"])) {
       reportError('incompletew3cjson', {error: "group"});
     } else {
+      // Note that `data.groups` is unused here.
       groups = arrayify(conf.group).map(id => parseInt(id, 10));
       shouldBeRepoManaged = conf["repo-type"] && (conf["repo-type"] === 'rec-track' || conf["repo-type"] === 'cg-report');
     }
@@ -134,17 +128,7 @@ function validateRepo(r, licenses, repoData, cgData, repoMap) {
       }
     }
   } else {
-    if (cg) {
-      groups = [cg.id];
-    } else if (r.owner.login === 'WICG') {
-      groups = [80485];
-    }
-    if (wgRepo && wgRepo.length) {
-      groups = groups.concat(wgRepo.map(x => x.group));
-    }
-    if (r.owner.login === 'WebAudio') {
-      groups.push(46884);
-    }
+    groups = data.groups;
     reportError('now3cjson');
   }
   const recTrackStatus = hasRecTrack.tr || hasRecTrack.ashnazg || hasRecTrack.repo;
@@ -177,7 +161,6 @@ function validateRepo(r, licenses, repoData, cgData, repoMap) {
 
   return {
     errors, groups,
-    isAshRepo: !!ashRepo,
     hasRecTrack: !!recTrackStatus,
   };
 }

--- a/lib/w3cData.js
+++ b/lib/w3cData.js
@@ -1,0 +1,61 @@
+/* eslint-env node */
+
+// Additional W3C data about a repo that isn't from the GitHub repo/API.
+
+"use strict";
+
+const fetch = require("node-fetch");
+const w3c = require("node-w3capi");
+
+const config = require("../config.json");
+w3c.apiKey = config.w3capikey;
+
+async function data() {
+  const [ashRepos, cgData, repoMap, w3cgroups] = await Promise.all([
+    fetch("https://labs.w3.org/hatchery/repo-manager/api/repos").then(r => r.json()),
+    fetch("https://w3c.github.io/cg-monitor/report.json").then(r => r.json()),
+    fetch("https://w3c.github.io/spec-dashboard/repo-map.json").then(r => r.json()),
+    // https://github.com/w3c/node-w3capi/issues/41
+    new Promise((resolve, reject) => {
+      w3c.groups().fetch({embed: true}, (err, w3cgroups) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(w3cgroups);
+        }
+      });
+    })
+  ]);
+
+  function get(owner, name) {
+    const fullName = `${owner}/${name}`;
+    const ashRepo = ashRepos.find(x => {
+      return x.owner.toLowerCase() === owner.toLowerCase() &&
+          x.name.toLowerCase() === name.toLowerCase();
+    }) || null;
+    const cg = cgData.data.find(cg => {
+      return cg.repositories.includes(`https://github.com/${fullName}`) ||
+          cg.repositories.includes(`https://github.com/${fullName}/`);
+    });
+    const specs = repoMap[fullName] || [];
+
+    const groups = [];
+    if (cg) {
+      groups.push(cg.id);
+    } else if (owner === 'WICG') {
+      groups.push(80485);
+    }
+    for (const spec of specs) {
+      groups.push(spec.group);
+    }
+    if (owner === 'WebAudio') {
+      groups.push(46884);
+    }
+
+    return {ashRepo, specs, groups};
+  }
+
+  return {get, w3cgroups};
+}
+
+module.exports = data;

--- a/test/validator.js
+++ b/test/validator.js
@@ -18,16 +18,17 @@ describe('validateRepo', () => {
       owner: {login: 'foo'},
       name: 'bar',
     };
+    const data = {
+      ashRepo: null,
+      specs: [],
+      groups: [],
+    };
     const licenses = {};
-    const repoData = [];
-    const cgData = {data: []};
-    const repoMap = {};
     const {
       errors,
-      isAshRepo,
       hasRecTrack,
       groups,
-    } = validateRepo(repo, licenses, repoData, cgData, repoMap);
+    } = validateRepo(repo, data, licenses);
     assert.deepStrictEqual(errors, [
       ['noreadme', null],
       ['nocodeofconduct', null],
@@ -35,7 +36,6 @@ describe('validateRepo', () => {
       ['nocontributing', null],
       ['now3cjson', null],
     ]);
-    assert.strictEqual(isAshRepo, false);
     assert.strictEqual(hasRecTrack, false);
     assert.deepStrictEqual(groups, []);
   });
@@ -47,16 +47,18 @@ describe('validateRepo', () => {
       contributing: {text: 'invalid CONTRIBUTING.md content'},
       license: {text: 'invalid LICENSE.md content'},
     };
+    const data = {
+      ashRepo: null,
+      specs: [],
+      groups: [],
+    };
     const licenses = {
       license: 'mock LICENSE.md content',
       licenseSw: 'mock LICENSE-SW.md content',
       contributing: 'mock CONTRIBUTING.md content',
       contributingSw: 'mock CONTRIBUTING-SW.md content',
     };
-    const repoData = [];
-    const cgData = {data: []};
-    const repoMap = {};
-    const {errors} = validateRepo(repo, licenses, repoData, cgData, repoMap);
+    const {errors} = validateRepo(repo, data, licenses);
     const types = ['invalidcontributing', 'invalidlicense']
     assert.deepStrictEqual(filter(errors, types), [
       ['invalidlicense', {
@@ -76,11 +78,13 @@ describe('validateRepo', () => {
       name: 'bar',
       prpreviewjson: {text: '{"aKey":"someValue"}'},
     };
+    const data = {
+      ashRepo: null,
+      specs: [],
+      groups: [],
+    };
     const licenses = {};
-    const repoData = [];
-    const cgData = {data: []};
-    const repoMap = {};
-    validateRepo(repo, licenses, repoData, cgData, repoMap);
+    validateRepo(repo, data, licenses);
     assert.deepStrictEqual(repo.prpreview, {aKey: 'someValue'});
   });
 
@@ -89,11 +93,13 @@ describe('validateRepo', () => {
       owner: {login: 'w3c'},
       name: 'markup-validator',
     };
+    const data = {
+      ashRepo: null,
+      specs: [],
+      groups: [],
+    };
     const licenses = {};
-    const repoData = [];
-    const cgData = {data: []};
-    const repoMap = {};
-    validateRepo(repo, licenses, repoData, cgData, repoMap);
+    validateRepo(repo, data, licenses);
     assert.deepStrictEqual(repo.w3c, {
       contacts: 'sideshowbarker',
       'repo-type': 'tool',
@@ -114,21 +120,21 @@ describe('validateRepo', () => {
         'repo-type': 'note',
       })},
     };
+    const data = {
+      ashRepo: null,
+      specs: [],
+      groups: [],
+    };
     const licenses = {
       license: 'mock LICENSE.md content',
       contributing: 'mock CONTRIBUTING.md content',
     };
-    const repoData = [];
-    const cgData = {data: []};
-    const repoMap = {};
     const {
       errors,
-      isAshRepo,
       hasRecTrack,
       groups,
-    } = validateRepo(repo, licenses, repoData, cgData, repoMap);
+    } = validateRepo(repo, data, licenses);
     assert.deepStrictEqual(errors, []);
-    assert.strictEqual(isAshRepo, false);
     assert.strictEqual(hasRecTrack, false);
     assert.deepStrictEqual(groups, [42]);
   });
@@ -152,89 +158,30 @@ describe('validateRepo', () => {
         }],
       },
     };
+    const data = {
+      ashRepo: {
+        owner: 'foo',
+        name: 'bar',
+        groups: [{
+          groupType: 'WG',
+          w3cid: '43',
+        }],
+      },
+      specs: [{recTrack: true}],
+      groups: [],
+    };
     const licenses = {
       license: 'mock LICENSE.md content',
       contributing: 'mock CONTRIBUTING.md content',
     };
-    const repoData = [{
-      owner: 'foo',
-      name: 'bar',
-      groups: [{
-        groupType: 'WG',
-        w3cid: '43',
-      }],
-    }];
-    const cgData = {data: []};
-    const repoMap = {
-      'foo/bar': [{recTrack: true}],
-    };
     const {
       errors,
-      isAshRepo,
       hasRecTrack,
       groups,
-    } = validateRepo(repo, licenses, repoData, cgData, repoMap);
+    } = validateRepo(repo, data, licenses);
     assert.deepStrictEqual(errors, []);
-    assert.strictEqual(isAshRepo, true);
     assert.strictEqual(hasRecTrack, true);
     assert.deepStrictEqual(groups, [43]);
-  });
-
-  it('groups for WG repo sans w3c.json', () => {
-    const repo = {
-      owner: {login: 'foo'},
-      name: 'bar',
-    };
-    const licenses = {};
-    const repoData = [];
-    const cgData = {data: []};
-    const repoMap = {
-      'foo/bar': [{group: 44}],
-    };
-    const {groups} = validateRepo(repo, licenses, repoData, cgData, repoMap);
-    assert.deepStrictEqual(groups, [44]);
-  });
-
-  it('groups for CG repo sans w3c.json', () => {
-    const repo = {
-      owner: {login: 'foo'},
-      name: 'bar',
-    };
-    const licenses = {};
-    const repoData = [];
-    const cgData = {data: [{
-      id: 45,
-      repositories: ['https://github.com/foo/bar/'],
-    }]};
-    const repoMap = {};
-    const {groups} = validateRepo(repo, licenses, repoData, cgData, repoMap);
-    assert.deepStrictEqual(groups, [45]);
-  });
-
-  it('groups for WICG repo sans w3c.json', () => {
-    const repo = {
-      owner: {login: 'WICG'},
-      name: 'bar',
-    };
-    const licenses = {};
-    const repoData = [];
-    const cgData = {data: []};
-    const repoMap = {};
-    const {groups} = validateRepo(repo, licenses, repoData, cgData, repoMap);
-    assert.deepStrictEqual(groups, [80485]);
-  });
-
-  it('groups for WebAudio WG repo sans w3c.json', () => {
-    const repo = {
-      owner: {login: 'WebAudio'},
-      name: 'bar',
-    };
-    const licenses = {};
-    const repoData = [];
-    const cgData = {data: []};
-    const repoMap = {};
-    const {groups} = validateRepo(repo, licenses, repoData, cgData, repoMap);
-    assert.deepStrictEqual(groups, [46884]);
   });
 
   it('ill-formed w3c.json', () => {
@@ -243,11 +190,13 @@ describe('validateRepo', () => {
       name: 'bar',
       w3cjson: {text: 'ill-formed JSON'},
     };
+    const data = {
+      ashRepo: null,
+      specs: [],
+      groups: [],
+    };
     const licenses = {};
-    const repoData = [];
-    const cgData = {data: []};
-    const repoMap = {};
-    const {errors} = validateRepo(repo, licenses, repoData, cgData, repoMap);
+    const {errors} = validateRepo(repo, data, licenses);
     assert.deepStrictEqual(filter(errors, ['illformedw3cjson']), [
       ['illformedw3cjson', null],
     ]);
@@ -259,15 +208,36 @@ describe('validateRepo', () => {
       name: 'bar',
       w3cjson: {text: '{}'},
     };
+    const data = {
+      ashRepo: null,
+      specs: [],
+      groups: [],
+    };
     const licenses = {};
-    const repoData = [];
-    const cgData = {data: []};
-    const repoMap = {};
-    const {errors} = validateRepo(repo, licenses, repoData, cgData, repoMap);
+    const {errors} = validateRepo(repo, data, licenses);
     assert.deepStrictEqual(filter(errors, ['incompletew3cjson']), [
       ['incompletew3cjson', {error: 'repo-type (unknown)'}],
       ['incompletew3cjson', {error: 'contacts'}],
     ]);
+  });
+
+  it('w3c.json groups', () => {
+    const repo = {
+      owner: {login: 'foo'},
+      name: 'bar',
+      w3cjson: {text: JSON.stringify({
+        contacts: [],
+        group: ['45'],
+      })},
+    };
+    const data = {
+      ashRepo: null,
+      specs: [{group: 43}],
+      groups: [45],
+    };
+    const licenses = {};
+    const {groups} = validateRepo(repo, data, licenses);
+    assert.deepStrictEqual(groups, [45]);
   });
 
   it('w3c.json invalid type and contacts', () => {
@@ -279,13 +249,13 @@ describe('validateRepo', () => {
         'repo-type': 'foo',
       })},
     };
-    const licenses = {};
-    const repoData = [];
-    const cgData = {data: []};
-    const repoMap = {
-      'foo/bar': [{recTrack: true}],
+    const data = {
+      ashRepo: null,
+      specs: [{recTrack: true}],
+      groups: [],
     };
-    const {errors} = validateRepo(repo, licenses, repoData, cgData, repoMap);
+    const licenses = {};
+    const {errors} = validateRepo(repo, data, licenses);
     assert.deepStrictEqual(filter(errors, ['invalidw3cjson']), [
       ['invalidw3cjson', {error: 'unknown types: ["foo"]'}],
       ['invalidw3cjson', {error: 'invalid contacts: [123]'}],
@@ -300,13 +270,13 @@ describe('validateRepo', () => {
         'repo-type': 'rec-track',
       })},
     };
-    const licenses = {};
-    const repoData = [];
-    const cgData = {data: []};
-    const repoMap = {
-      'foo/bar': [{recTrack: true}],
+    const data = {
+      ashRepo: null,
+      specs: [{recTrack: true}],
+      groups: [],
     };
-    const {errors} = validateRepo(repo, licenses, repoData, cgData, repoMap);
+    const licenses = {};
+    const {errors} = validateRepo(repo, data, licenses);
     const types = ['noashnazg', 'unprotectedbranch'];
     assert.deepStrictEqual(filter(errors, types), [
       ['noashnazg', null],
@@ -320,17 +290,17 @@ describe('validateRepo', () => {
       name: 'bar',
       w3cjson: {text: JSON.stringify({'repo-type': 'rec-track'})},
     };
-    const licenses = {};
-    const repoData = [{
-      owner: 'foo',
-      name: 'bar',
-      groups: [{groupType: 'CG'}],
-    }];
-    const cgData = {data: []};
-    const repoMap = {
-      'foo/bar': [{recTrack: true}],
+    const data = {
+      ashRepo: {
+        owner: 'foo',
+        name: 'bar',
+        groups: [{groupType: 'CG'}],
+      },
+      specs: [{recTrack: true}],
+      groups: [],
     };
-    const {errors} = validateRepo(repo, licenses, repoData, cgData, repoMap);
+    const licenses = {};
+    const {errors} = validateRepo(repo, data, licenses);
     assert.deepStrictEqual(filter(errors, ['inconsistentstatus']), [
       ['inconsistentstatus', {error: 'TR document: true, vs repo manager: false'}],
       ['inconsistentstatus', {error: 'repo: true, vs repo manager: false'}],
@@ -343,17 +313,17 @@ describe('validateRepo', () => {
       name: 'bar',
       w3cjson: {text: JSON.stringify({'repo-type': 'rec-track'})},
     };
-    const licenses = {};
-    const repoData = [{
-      owner: 'foo',
-      name: 'bar',
-      groups: [{groupType: 'WG'}],
-    }];
-    const cgData = {data: []};
-    const repoMap = {
-      'foo/bar': [{recTrack: false}],
+    const data = {
+      ashRepo: {
+        owner: 'foo',
+        name: 'bar',
+        groups: [{groupType: 'WG'}],
+      },
+      specs: [{recTrack: false}],
+      groups: [],
     };
-    const {errors} = validateRepo(repo, licenses, repoData, cgData, repoMap);
+    const licenses = {};
+    const {errors} = validateRepo(repo, data, licenses);
     assert.deepStrictEqual(filter(errors, ['inconsistentstatus']), [
       ['inconsistentstatus', {error: 'TR document: false, vs repo: true'}],
       ['inconsistentstatus', {error: 'TR document: false, vs repo manager: true'}],

--- a/test/w3cData.js
+++ b/test/w3cData.js
@@ -1,0 +1,153 @@
+/* eslint-env node, mocha */
+
+'use strict';
+
+const assert = require('assert');
+const proxyquire = require('proxyquire');
+
+// Most things can be tested well enough without varying what the w3cData
+// required modules, so set up constant mock data up front.
+const w3cData = proxyquire('../lib/w3cData.js', {
+  'node-fetch': async (url) => {
+    const data = ({
+      'https://labs.w3.org/hatchery/repo-manager/api/repos': [
+        {
+          owner: 'w3c',
+          name: 'IndexedDB',
+        },
+      ],
+      'https://w3c.github.io/cg-monitor/report.json': {
+        data: [
+          {
+            id: 54172,
+            repositories: ['https://github.com/w3c/speech-api/'],
+          }
+        ]
+      },
+      'https://w3c.github.io/spec-dashboard/repo-map.json': {
+        'w3c/IndexedDB': [{
+          recTrack: true,
+          url: 'https://www.w3.org/TR/IndexedDB/',
+          group: 114929,
+        }],
+        'w3c/ServiceWorker': [{
+          recTrack: true,
+          url: 'https://www.w3.org/TR/service-workers-1/',
+          group: 101220,
+        }],
+      }
+    })[url];
+    return {
+      async json() {
+        return data;
+      }
+    }
+  },
+  'node-w3capi': {
+    groups() {
+      return {
+        fetch(options, callback) {
+          callback(null, ['mock-w3cgroups']);
+        }
+      }
+    }
+  }
+});
+
+describe('w3cData', () => {
+  let data;
+
+  before(async () => {
+    data = await w3cData();
+  });
+
+  it('repo with all data', () => {
+    const {ashRepo, specs, groups} = data.get('w3c', 'IndexedDB');
+    assert.deepStrictEqual(ashRepo, {owner: 'w3c', name: 'IndexedDB'});
+    assert.deepStrictEqual(specs, [{
+      recTrack: true,
+      url: 'https://www.w3.org/TR/IndexedDB/',
+      group: 114929,
+    }]);
+    assert.deepStrictEqual(groups, [114929]);
+  });
+
+  it('repo with no data', () => {
+    const {ashRepo, specs, groups} = data.get('foo', 'bar');
+    assert.strictEqual(ashRepo, null);
+    assert.deepStrictEqual(specs, []);
+    assert.deepStrictEqual(groups, []);
+  });
+
+  it('groups for WG repo', () => {
+    const {groups} = data.get('w3c', 'ServiceWorker');
+    assert.deepStrictEqual(groups, [101220]);
+  });
+
+  it('groups for CG repo', () => {
+    const {groups} = data.get('w3c', 'speech-api');
+    assert.deepStrictEqual(groups, [54172]);
+  });
+
+  it('groups for WICG repo', () => {
+    const {groups} = data.get('WICG', 'bar');
+    assert.deepStrictEqual(groups, [80485]);
+  });
+
+  it('groups for WebAudio WG repo', () => {
+    const {groups} = data.get('WebAudio', 'bar');
+    assert.deepStrictEqual(groups, [46884]);
+  });
+
+  it('w3cgroups', () => {
+    assert.deepStrictEqual(data.w3cgroups, ['mock-w3cgroups']);
+  });
+
+  it('fetch error', async () => {
+    const w3cData = proxyquire('../lib/w3cData.js', {
+      'node-fetch': async () => {
+        return {
+          async json() {
+            throw new Error('mock fetch error');
+          }
+        }
+      },
+      'node-w3capi': {
+        groups() {
+          return {
+            fetch(options, callback) {
+              callback(null, []);
+            }
+          }
+        }
+      }
+    });
+    await assert.rejects(w3cData(), {
+      message: 'mock fetch error'
+    });
+  });
+
+  it('W3C API error', async () => {
+    const w3cData = proxyquire('../lib/w3cData.js', {
+      'node-fetch': async () => {
+        return {
+          async json() {
+            return null;
+          }
+        }
+      },
+      'node-w3capi': {
+        groups() {
+          return {
+            fetch(options, callback) {
+              callback(new Error('mock w3c error'));
+            }
+          }
+        }
+      }
+    });
+    await assert.rejects(w3cData(), {
+      message: 'mock w3c error'
+    });
+  });
+});


### PR DESCRIPTION
This allows more of the code to be tested, and is a more reasonable
interface, as `validateRepo` doesn't need information related to all
repositories.