### PR TITLE
Expand branch protection checks to admins and required review

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -143,10 +143,25 @@ function validateRepo(r, data, licenses) {
         reportError('inconsistentgroups', {ashnazgroups: ashGroups, error: JSON.stringify(groups) + ' vs ' + JSON.stringify(ashGroups)});
       }
     }
-  }
-  if (recTrackStatus) {
-    if (!r.branchProtectionRules || r.branchProtectionRules.nodes.length < 1) {
-      reportError('unprotectedbranch', {error: "No protected branch"});
+
+    if (!r.defaultBranch || !r.defaultBranch.name) {
+      // This ought to only happen for an empty repository.
+      reportError('nodefaultbranch');
+    } else {
+      const defaultBranch = r.defaultBranch.name;
+      const rule = r.branchProtectionRules
+        ? r.branchProtectionRules.nodes.find(rule => rule.pattern === defaultBranch)
+        : null;
+      if (!rule) {
+        reportError('unprotectedbranch', {error: `${defaultBranch} branch is not protected`});
+      } else {
+        if (!rule.isAdminEnforced) {
+          reportError('unprotectedbranchforadmin', {error: `${defaultBranch} branch protection is not admin enforced`});
+        }
+        if (!(rule.requiredApprovingReviewCount > 0)) {
+          reportError('norequiredreview', {error: `${defaultBranch} branch review is not required`});
+        }
+      }
     }
   }
   if (hasRecTrack.tr !== null && hasRecTrack.repotype !== null && hasRecTrack.tr !== hasRecTrack.repotype) {

--- a/report.js
+++ b/report.js
@@ -8,6 +8,8 @@ const errortypes = {
   "inconsistentstatus": "Inconsistent rec-track status",
   "inconsistentgroups": "Inconsistent groups info w3c.json / repo-manager",
   "unprotectedbranch": "Missing branch protection rule",
+  "unprotectedbranchforadmin": "Missing admin enforced branch protection",
+  "norequiredreview": "Missing required review setting",
   "nocontributing": "No CONTRIBUTING.md file",
   "missingashnazghook": "Configured with the Repo Manager, but missing the github webhook",
   "duplicateashnazghooks": "Duplicate Repo Manager webhooks",

--- a/validate.js
+++ b/validate.js
@@ -14,7 +14,26 @@ const config = require("./config.json");
 const octo = new Octokat({token: config.ghToken});
 
 const orgs = ["w3c", "WebAudio", "immersive-web", "webassembly", "w3ctag", "WICG", "w3cping"];
-const errortypes = ["inconsistentgroups", "now3cjson", "invalidw3cjson", "illformedw3cjson", "incompletew3cjson", "nocontributing", "invalidcontributing", "nolicense", "nocodeofconduct", "invalidlicense", "noreadme", "noashnazg", "inconsistentstatus", "unprotectedbranch", "missingashnazghook", "duplicateashnazghooks"];
+const errortypes = [
+  "inconsistentgroups",
+  "now3cjson",
+  "invalidw3cjson",
+  "illformedw3cjson",
+  "incompletew3cjson",
+  "nocontributing",
+  "invalidcontributing",
+  "nolicense",
+  "nocodeofconduct",
+  "invalidlicense",
+  "noreadme",
+  "noashnazg",
+  "inconsistentstatus",
+  "unprotectedbranch",
+  "unprotectedbranchforadmin",
+  "norequiredreview",
+  "missingashnazghook",
+  "duplicateashnazghooks"
+];
 
 async function fetchLabelPage(org, repo, acc = {edges: []}, cursor = null) {
   console.warn("Fetching labels for " + repo);


### PR DESCRIPTION
Neither error is shown by default in report.html, as it's still
unclear if these policies have corner cases where they're a bad
idea. Candidate repos to discuss the tradeoffs with will be taken from
the resulting report.