### PR TITLE
Make list of rec-track repos the baseline of HR repos

### DIFF
--- a/extract-horizontal-reviews.js
+++ b/extract-horizontal-reviews.js
@@ -8,7 +8,10 @@ const hrLabelRegexp = new RegExp(/-(tracker|needs-resolution)$/);
 const isHRLabel = n => n.name.match(hrLabelRegexp);
 
 console.log(JSON.stringify(
-  repos.filter(r => r.labels && r.labels.find(isHRLabel))
+  repos.filter(r => r.labels && r.labels.find(isHRLabel) ||
+    (r.w3c && r.w3c["repo-type"]
+    && (r.w3c["repo-type"] === "rec-track" ||
+    r.w3c["repo-type"].includes("rec-track"))))
     .map(r => r.owner.login + "/" + r.name),
   null,
   2)


### PR DESCRIPTION
To deal with current unreliability of label extraction cf #67