### PR TITLE
Fix report filtering controls in report.html

### DIFF
--- a/report.js
+++ b/report.js
@@ -1,5 +1,6 @@
 /* eslint-env browser */
 
+let data;
 const errortypes = {
   "now3cjson": "No w3c.json file",
   "invalidw3cjson": "Invalid data in w3c.json",
@@ -81,7 +82,10 @@ const writeErrorEntry = (name, list, details) => {
   list.appendChild(li);
 };
 
-function writeReport(data) {
+function writeReport() {
+  if (!data) {
+    return;
+  }
   const mentionedRepos = new Set();
   const groupFilter = gid => getUrlParam("grouptype") ? (groups[gid].type || '').replace(' ', '') === getUrlParam("grouptype") : true;
   const errorFilter = new Set((getUrlParam("filter") || defaultReport.join(',')).split(",").filter(e => e !== ''));
@@ -151,4 +155,7 @@ function writeReport(data) {
 
 fetch("report.json")
   .then(r => r.json())
-  .then(writeReport);
+  .then(fetcheddata => {
+    data = fetcheddata;
+    writeReport();
+  });


### PR DESCRIPTION
This was broken by https://github.com/w3c/validate-repos/pull/57
because `writeReport()` is called when the form state changes, but
without passing the data argument. Revert back to the original way of
using a global `data` variable.