### PR TITLE
Avoid GH Actions infinite loop

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -31,7 +31,7 @@ jobs:
         git commit -m "Update report.json, rec-track-repos.json, hr-repos.json"
         git show
     - name: Push changes
-      if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master' && github.actor != 'dontcallmedom-bot'
       run: |
         git remote set-url --push origin https://x-access-token:${{ secrets.W3C_GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
         git push origin HEAD:master


### PR DESCRIPTION
When we switched from using GITHUB_TOKEN to using a Personal Access Token (cf 5e4ccc938d7d5d5aef2d0d00b4aa4830e0491570), we inadvertedly got rid of the loop protection provided by github token.

This adds a condition to the push to avoid that loop as suggested in https://github.community/t5/GitHub-Actions/Autofix-workflow-on-a-pull-request-invalidates-previous-check/m-p/33879#M1693