### PR TITLE
Stop catching errors for graphql queries instead fail fast

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -11,9 +11,7 @@ const octo = new Octokat({token: config.ghToken});
 
 async function fetchLabelPage(org, repo, acc = {edges: []}, cursor = null) {
   console.warn("Fetching labels for " + repo);
-  let res;
-  try {
-    res = await graphql(`
+  const res = await graphql(`
  query {
     repository(owner:"${org}",name:"${repo}") {
         labels(first:10 ${cursor ? 'after:"' + cursor + '"' : ''}) {
@@ -31,29 +29,16 @@ async function fetchLabelPage(org, repo, acc = {edges: []}, cursor = null) {
     }
 
 }`);
-  } catch (err) {
-    // istanbul ignore next
-    console.error("query failed " + JSON.stringify(err));
-  }
-  // istanbul ignore else
-  if (res && res.repository) {
-    const labels = {edges: acc.edges.concat(res.repository.labels.edges)};
-    if (res.repository.labels.pageInfo.hasNextPage) {
-      return fetchLabelPage(org, repo, labels, res.repository.labels.pageInfo.endCursor);
-    } else {
-      return {"repo": {"owner": org, "name": repo}, labels};
-    }
+  const labels = {edges: acc.edges.concat(res.repository.labels.edges)};
+  if (res.repository.labels.pageInfo.hasNextPage) {
+    return fetchLabelPage(org, repo, labels, res.repository.labels.pageInfo.endCursor);
   } else {
-    console.error("Fetching label for " + repo + " at cursor " + cursor + " failed with " + JSON.stringify(res) + ", not retrying");
-    return {"repo": {"owner": org, "name": repo}, "labels": acc};
-    //return fetchLabelPage(org, repo, acc, cursor);
+    return {"repo": {"owner": org, "name": repo}, labels};
   }
 }
 
 async function fetchRepoPage(org, acc = [], cursor = null) {
-  let res;
-  try {
-    res = await graphql(`
+  const res = await graphql(`
  query {
   organization(login:"${org}") {
     repositories(first:10 ${cursor ? 'after:"' + cursor + '"' : ''}) {
@@ -125,39 +110,29 @@ async function fetchRepoPage(org, acc = [], cursor = null) {
     resetAt
   }
  }`);
-  } catch (err) {
-    // istanbul ignore next
-    console.error(err);
-  }
+  console.error("GitHub rate limit: " + JSON.stringify(res.rateLimit));
   // Fetch labels if they are paginated
-  // istanbul ignore else
-  if (res && res.organization) {
-    console.error("GitHub rate limit: " + JSON.stringify(res.rateLimit));
-    return Promise.all(
-      res.organization.repositories.edges
-        .filter(e => e.node.labels.pageInfo.hasNextPage)
-        .map(e => fetchLabelPage(e.node.owner.login, e.node.name, e.node.labels, e.node.labels.pageInfo.endCursor))
-    ).then((labelsPerRepos) => {
-      const data = acc.concat(res.organization.repositories.edges.map(e => e.node));
-      labelsPerRepos.forEach(({repo, labels}) => {
-        data.find(r => r.owner.login == repo.owner && r.name == repo.name).labels = labels;
-      });
-      // Clean up labels data structure
-      data.forEach(r => {
-        if (r.labels && r.labels.edges) {
-          r.labels = r.labels.edges.map(e => e.node);
-        }
-      });
-      if (res.organization.repositories.pageInfo.hasNextPage) {
-        return fetchRepoPage(org, data, res.organization.repositories.pageInfo.endCursor);
-      } else {
-        return data;
+  return Promise.all(
+    res.organization.repositories.edges
+      .filter(e => e.node.labels.pageInfo.hasNextPage)
+      .map(e => fetchLabelPage(e.node.owner.login, e.node.name, e.node.labels, e.node.labels.pageInfo.endCursor))
+  ).then((labelsPerRepos) => {
+    const data = acc.concat(res.organization.repositories.edges.map(e => e.node));
+    labelsPerRepos.forEach(({repo, labels}) => {
+      data.find(r => r.owner.login == repo.owner && r.name == repo.name).labels = labels;
+    });
+    // Clean up labels data structure
+    data.forEach(r => {
+      if (r.labels && r.labels.edges) {
+        r.labels = r.labels.edges.map(e => e.node);
       }
     });
-  } else {
-    console.error("Fetching repo results at cursor " + cursor + " failed, retrying");
-    return fetchRepoPage(org, acc, cursor);
-  }
+    if (res.organization.repositories.pageInfo.hasNextPage) {
+      return fetchRepoPage(org, data, res.organization.repositories.pageInfo.endCursor);
+    } else {
+      return data;
+    }
+  });
 }
 
 async function fetchRepoHooks(org, repo) {


### PR DESCRIPTION
In https://github.com/w3c/validate-repos/pull/77, rate limits kicked
in but the validate check still passed. This could mask real
regressions, and can keep hammering the GitHub APIs on error.