### PR TITLE
Use @octokit/core + @octokit/plugin-throttling for GraphQL

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -9,63 +9,25 @@ const graphql = require("./graphql.js");
 const Octokat = require("octokat");
 const octo = new Octokat({token: config.ghToken});
 
-async function fetchLabelPage(org, repo, acc = {edges: []}, cursor = null) {
-  console.warn("Fetching labels for " + repo);
-  let res;
-  try {
-    res = await graphql(`
- query {
-    repository(owner:"${org}",name:"${repo}") {
-        labels(first:10 ${cursor ? 'after:"' + cursor + '"' : ''}) {
-            edges {
-              node {
-                name
-                color
-              }
-            }
-            pageInfo {
-              endCursor
-              hasNextPage
-            }
-         }
-    }
-
-}`);
-  } catch (err) {
-    // istanbul ignore next
-    console.error("query failed " + JSON.stringify(err));
-  }
-  // istanbul ignore else
-  if (res && res.repository) {
-    const labels = {edges: acc.edges.concat(res.repository.labels.edges)};
-    if (res.repository.labels.pageInfo.hasNextPage) {
-      return fetchLabelPage(org, repo, labels, res.repository.labels.pageInfo.endCursor);
-    } else {
-      return {"repo": {"owner": org, "name": repo}, labels};
-    }
-  } else {
-    console.error("Fetching label for " + repo + " at cursor " + cursor + " failed with " + JSON.stringify(res) + ", not retrying");
-    return {"repo": {"owner": org, "name": repo}, "labels": acc};
-    //return fetchLabelPage(org, repo, acc, cursor);
-  }
-}
-
-async function fetchRepoPage(org, acc = [], cursor = null) {
-  let res;
-  try {
-    res = await graphql(`
- query {
-  organization(login:"${org}") {
-    repositories(first:10 ${cursor ? 'after:"' + cursor + '"' : ''}) {
-      edges {
-        node {
-          id, name, owner { login } , isArchived, homepageUrl, description, isPrivate, createdAt
-          labels(first:10) {
-            edges {
-              node {
-                name
-                color
-              }
+const repoQuery = `
+  query ($org: String!, $cursor: String) {
+    organization(login: $org) {
+      repositories(first: 10, after: $cursor) {
+        nodes {
+          id
+          name
+          owner {
+            login
+          }
+          isArchived
+          homepageUrl
+          description
+          isPrivate
+          createdAt
+          labels(first: 100) {
+            nodes {
+              name
+              color
             }
             pageInfo {
               endCursor
@@ -103,66 +65,70 @@ async function fetchRepoPage(org, acc = [], cursor = null) {
               text
             }
           }
-          codeOfConduct { body }
+          codeOfConduct {
+            body
+          }
           readme: object(expression: "HEAD:README.md") {
             ... on Blob {
               text
             }
           }
         }
-        cursor
-      }
-      pageInfo {
-        endCursor
-        hasNextPage
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
       }
     }
   }
-  rateLimit {
-    limit
-    cost
-    remaining
-    resetAt
-  }
- }`);
-  } catch (err) {
-    // istanbul ignore next
-    console.error(err);
-  }
-  // Fetch labels if they are paginated
-  // istanbul ignore else
-  if (res && res.organization) {
-    console.error("GitHub rate limit: " + JSON.stringify(res.rateLimit));
-    return Promise.all(
-      res.organization.repositories.edges
-        .filter(e => e.node.labels.pageInfo.hasNextPage)
-        .map(e => fetchLabelPage(e.node.owner.login, e.node.name, e.node.labels, e.node.labels.pageInfo.endCursor))
-    ).then((labelsPerRepos) => {
-      const data = acc.concat(res.organization.repositories.edges.map(e => e.node));
-      labelsPerRepos.forEach(({repo, labels}) => {
-        data.find(r => r.owner.login == repo.owner && r.name == repo.name).labels = labels;
-      });
-      // Clean up labels data structure
-      data.forEach(r => {
-        if (r.labels && r.labels.edges) {
-          r.labels = r.labels.edges.map(e => e.node);
+`;
+
+const labelQuery = `
+  query ($org: String!, $repo: String!, $cursor: String!) {
+    repository(owner: $org, name: $repo) {
+      labels(first: 100, after: $cursor) {
+        nodes {
+          name
+          color
         }
-      });
-      if (res.organization.repositories.pageInfo.hasNextPage) {
-        return fetchRepoPage(org, data, res.organization.repositories.pageInfo.endCursor);
-      } else {
-        return data;
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
       }
-    });
-  } else {
-    console.error("Fetching repo results at cursor " + cursor + " failed, retrying");
-    return fetchRepoPage(org, acc, cursor);
+    }
+  }
+`;
+
+async function *listRepos(org) {
+  for (let cursor = null; ;) {
+    const res = await graphql(repoQuery, {org, cursor});
+    for (const repo of res.organization.repositories.nodes) {
+      const labels = repo.labels.nodes;
+      // Fetch more labels if they are paginated
+      for (let pageInfo = repo.labels.pageInfo; pageInfo.hasNextPage;) {
+        const res = await graphql(labelQuery, {
+          org,
+          repo: repo.name,
+          cursor: pageInfo.endCursor
+        });
+        labels.push(...res.repository.labels.nodes);
+        pageInfo = res.repository.labels.pageInfo;
+      }
+      repo.labels = labels;
+      yield repo;
+    }
+    if (res.organization.repositories.pageInfo.hasNextPage) {
+      cursor = res.organization.repositories.pageInfo.endCursor;
+    } else {
+      break;
+    }
   }
 }
 
-async function fetchRepoHooks(org, repo) {
+async function listRepoHooks(org, repo) {
   const hooks = await octo.repos(`${org}/${repo}`).hooks.fetch();
   return hooks.items;
 }
 
-module.exports = {fetchRepoPage, fetchRepoHooks};
+module.exports = {listRepos, listRepoHooks};

--- a/lib/graphql.js
+++ b/lib/graphql.js
@@ -1,40 +1,36 @@
 /* eslint-env node */
+/* istanbul ignore file */
 
 "use strict";
 
 const config = require("../config.json");
-const fetch = require("node-fetch");
+const Octokit = require("@octokit/core").Octokit
+  .plugin(require("@octokit/plugin-throttling"));
 
-const GH_API = "https://api.github.com/graphql";
+const MAX_RETRIES = 3;
 
-// use https://developer.github.com/v4/explorer/ to debug queries
-
-const GH_HEADERS = {
-  "Accept": "application/vnd.github.v4.idl",
-  "User-Agent": "graphql-github/0.1",
-  "Content-Type": "application/json",
-  "Authorization": "bearer " + config.ghToken
-};
-
-async function graphql(query) {
-  const options = {
-    method: 'POST',
-    headers: GH_HEADERS,
-    body: JSON.stringify({query})
-  };
-
-  const obj = await fetch(GH_API, options).then(res => res.json());
-
-  if (obj.errors) {
-    const ghErr = obj.errors[0]; // just return the first error
-    const err = new Error(ghErr.message, "unknown", -1);
-    if (ghErr.type) {
-      err.type = ghErr.type;
+const octokit = new Octokit({
+  auth: config.ghToken,
+  throttle: {
+    onRateLimit: (retryAfter, options) => {
+      if (options.request.retryCount < MAX_RETRIES) {
+        console.warn(`Rate limit exceeded, retrying after ${retryAfter} seconds`)
+        return true;
+      } else {
+        console.error(`Rate limit exceeded, giving up after ${MAX_RETRIES} retries`);
+        return false;
+      }
+    },
+    onAbuseLimit: (retryAfter, options) => {
+      if (options.request.retryCount < MAX_RETRIES) {
+        console.warn(`Abuse detected triggered, retrying after ${retryAfter} seconds`)
+        return true;
+      } else {
+        console.error(`Abuse detected triggered, giving up after ${MAX_RETRIES} retries`);
+        return false;
+      }
     }
-    err.all = obj.errors;
-    throw err;
   }
-  return obj.data;
-}
+});
 
-module.exports = graphql;
+module.exports = octokit.graphql;

--- a/lib/w3cLicenses.js
+++ b/lib/w3cLicenses.js
@@ -8,36 +8,30 @@ const graphql = require("./graphql.js");
 // Set up the config of this repository
 async function licenses() {
   let res = await graphql(`
-  query {
-    repository(owner:"w3c",name:"licenses") {
-      contributing: object(expression: "HEAD:WG-CONTRIBUTING.md") {
-        ... on Blob {
-          text
+    query {
+      repository(owner: "w3c", name: "licenses") {
+        contributing: object(expression: "HEAD:WG-CONTRIBUTING.md") {
+          ... on Blob {
+            text
+          }
         }
-      }
-      contributingSw: object(expression: "HEAD:WG-CONTRIBUTING-SW.md") {
-        ... on Blob {
-          text
+        contributingSw: object(expression: "HEAD:WG-CONTRIBUTING-SW.md") {
+          ... on Blob {
+            text
+          }
         }
-      }
-      license: object(expression: "HEAD:WG-LICENSE.md") {
-        ... on Blob {
-          text
+        license: object(expression: "HEAD:WG-LICENSE.md") {
+          ... on Blob {
+            text
+          }
         }
-      }
-      licenseSw: object(expression: "HEAD:WG-LICENSE-SW.md") {
-        ... on Blob {
-          text
+        licenseSw: object(expression: "HEAD:WG-LICENSE-SW.md") {
+          ... on Blob {
+            text
+          }
         }
       }
     }
-  rateLimit {
-    limit
-    cost
-    remaining
-    resetAt
-  }
-  }
   `);
   res = res.repository;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -109,6 +109,95 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@octokit/auth-token": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.0.tgz",
+      "integrity": "sha512-eoOVMjILna7FVQf96iWc3+ZtE/ZT6y8ob8ZzcqKY1ibSQCnu4O/B7pJvzMx5cyZ/RjAff6DAdEb0O0Cjcxidkg==",
+      "requires": {
+        "@octokit/types": "^2.0.0"
+      }
+    },
+    "@octokit/core": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-2.1.2.tgz",
+      "integrity": "sha512-cMKjowQkNOHN9d6SmZsdjbuHarBmmvl7OeFv+6VDp0hTObuEqO6N/lh8buOD6wwK04RcvJ9sq5bEvF47oWeJIQ==",
+      "requires": {
+        "@octokit/auth-token": "^2.4.0",
+        "@octokit/graphql": "^4.3.1",
+        "@octokit/request": "^5.3.1",
+        "@octokit/types": "^2.0.0",
+        "before-after-hook": "^2.1.0",
+        "universal-user-agent": "^4.0.0"
+      }
+    },
+    "@octokit/endpoint": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.5.1.tgz",
+      "integrity": "sha512-nBFhRUb5YzVTCX/iAK1MgQ4uWo89Gu0TH00qQHoYRCsE12dWcG1OiLd7v2EIo2+tpUKPMOQ62QFy9hy9Vg2ULg==",
+      "requires": {
+        "@octokit/types": "^2.0.0",
+        "is-plain-object": "^3.0.0",
+        "universal-user-agent": "^4.0.0"
+      }
+    },
+    "@octokit/graphql": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.3.1.tgz",
+      "integrity": "sha512-hCdTjfvrK+ilU2keAdqNBWOk+gm1kai1ZcdjRfB30oA3/T6n53UVJb7w0L5cR3/rhU91xT3HSqCd+qbvH06yxA==",
+      "requires": {
+        "@octokit/request": "^5.3.0",
+        "@octokit/types": "^2.0.0",
+        "universal-user-agent": "^4.0.0"
+      }
+    },
+    "@octokit/plugin-throttling": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-2.7.0.tgz",
+      "integrity": "sha512-NMx7LI+eHu9tSb9U5s/OuGi/fIX7GUzfPJy00g2EJstt35Dug2cytA1P4WXxG1GSjUuZgalUfLg0G+nZKpaVpw==",
+      "requires": {
+        "bottleneck": "^2.15.3"
+      }
+    },
+    "@octokit/request": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.3.1.tgz",
+      "integrity": "sha512-5/X0AL1ZgoU32fAepTfEoggFinO3rxsMLtzhlUX+RctLrusn/CApJuGFCd0v7GMFhF+8UiCsTTfsu7Fh1HnEJg==",
+      "requires": {
+        "@octokit/endpoint": "^5.5.0",
+        "@octokit/request-error": "^1.0.1",
+        "@octokit/types": "^2.0.0",
+        "deprecation": "^2.0.0",
+        "is-plain-object": "^3.0.0",
+        "node-fetch": "^2.3.0",
+        "once": "^1.4.0",
+        "universal-user-agent": "^4.0.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+        }
+      }
+    },
+    "@octokit/request-error": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.2.0.tgz",
+      "integrity": "sha512-DNBhROBYjjV/I9n7A8kVkmQNkqFAMem90dSxqvPq57e2hBr7mNTX98y3R2zDpqMQHVRpBDjsvsfIGgBzy+4PAg==",
+      "requires": {
+        "@octokit/types": "^2.0.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "@octokit/types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.0.2.tgz",
+      "integrity": "sha512-StASIL2lgT3TRjxv17z9pAqbnI7HGu9DrJlg3sEBFfCLaMEqp+O3IQPUF6EZtQ4xkAu2ml6kMBBCtGxjvmtmuQ==",
+      "requires": {
+        "@types/node": ">= 8"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",
@@ -144,6 +233,11 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
+    },
+    "@types/node": {
+      "version": "12.12.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.17.tgz",
+      "integrity": "sha512-Is+l3mcHvs47sKy+afn2O1rV4ldZFU7W8101cNlOd+MRbjM4Onida8jSZnJdTe/0Pcf25g9BNIUsuugmE6puHA=="
     },
     "acorn": {
       "version": "7.1.0",
@@ -253,6 +347,16 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "before-after-hook": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
+      "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A=="
+    },
+    "bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -448,7 +552,6 @@
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-      "dev": true,
       "requires": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
@@ -460,8 +563,7 @@
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
     },
@@ -508,6 +610,11 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
+    "deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -535,6 +642,14 @@
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
         "iconv-lite": "~0.4.13"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "requires": {
+        "once": "^1.4.0"
       }
     },
     "error-ex": {
@@ -704,6 +819,20 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "execa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "requires": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      }
+    },
     "external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -867,6 +996,14 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
+    },
+    "get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "requires": {
+        "pump": "^3.0.0"
+      }
     },
     "glob": {
       "version": "7.1.6",
@@ -1088,6 +1225,14 @@
       "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
       "dev": true
     },
+    "is-plain-object": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+      "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+      "requires": {
+        "isobject": "^4.0.0"
+      }
+    },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
@@ -1126,8 +1271,12 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "isobject": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+      "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
     },
     "istanbul-lib-coverage": {
       "version": "2.0.5",
@@ -1332,6 +1481,11 @@
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       }
+    },
+    "macos-release": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz",
+      "integrity": "sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA=="
     },
     "make-dir": {
       "version": "2.1.0",
@@ -1542,8 +1696,7 @@
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "nise": {
       "version": "1.5.2",
@@ -1612,6 +1765,14 @@
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         }
+      }
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "requires": {
+        "path-key": "^2.0.0"
       }
     },
     "nyc": {
@@ -1694,7 +1855,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -1738,11 +1898,25 @@
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
+    "os-name": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
+      "integrity": "sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==",
+      "requires": {
+        "macos-release": "^2.2.0",
+        "windows-release": "^3.1.0"
+      }
+    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
       "version": "2.2.1",
@@ -1814,8 +1988,7 @@
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
       "version": "1.0.6",
@@ -1892,6 +2065,15 @@
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "punycode": {
       "version": "2.1.1",
@@ -2040,7 +2222,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
       "requires": {
         "shebang-regex": "^1.0.0"
       }
@@ -2048,14 +2229,12 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "sinon": {
       "version": "7.5.0",
@@ -2222,6 +2401,11 @@
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+    },
     "strip-json-comments": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
@@ -2376,6 +2560,14 @@
         }
       }
     },
+    "universal-user-agent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.0.tgz",
+      "integrity": "sha512-eM8knLpev67iBDizr/YtqkJsF3GK8gzDc6st/WKzrTuPtcsOKW/0IdL4cnMBsU69pOx0otavLWBDGTwg+dB0aA==",
+      "requires": {
+        "os-name": "^3.1.0"
+      }
+    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -2416,7 +2608,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -2467,6 +2658,14 @@
             "ansi-regex": "^3.0.0"
           }
         }
+      }
+    },
+    "windows-release": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.2.0.tgz",
+      "integrity": "sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==",
+      "requires": {
+        "execa": "^1.0.0"
       }
     },
     "word-wrap": {
@@ -2520,8 +2719,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "test": "nyc mocha"
   },
   "dependencies": {
+    "@octokit/core": "2.1.2",
+    "@octokit/plugin-throttling": "2.7.0",
     "node-fetch": "^1.6.3",
     "node-w3capi": "^1.4.0",
     "octokat": "^0.7.0"

--- a/test/github.js
+++ b/test/github.js
@@ -7,28 +7,32 @@ const proxyquire = require('proxyquire');
 const sinon = require('sinon');
 
 describe('github', () => {
-  describe('fetchRepoPage', () => {
+  describe('listRepos', () => {
+    async function toArray(iterator) {
+      const array = [];
+      for await (const item of iterator) {
+        array.push(item);
+      }
+      return array;
+    }
+
     it('one repo, one label', async () => {
       const graphql = sinon.stub();
       graphql.resolves({
         organization: {
           repositories: {
-            edges: [
+            nodes: [
               {
-                node: {
-                  owner: {login: 'WICG'},
-                  name: 'speech-api',
-                  labels: {
-                    edges: [
-                      {
-                        node: {
-                          name: 'mock-label',
-                          color: 'ffffff',
-                        }
-                      }
-                    ],
-                    pageInfo: {hasNextPage: false}
-                  }
+                owner: {login: 'WICG'},
+                name: 'speech-api',
+                labels: {
+                  nodes: [
+                    {
+                      name: 'mock-label',
+                      color: 'ffffff',
+                    }
+                  ],
+                  pageInfo: {hasNextPage: false}
                 }
               }
             ],
@@ -39,7 +43,7 @@ describe('github', () => {
       const github = proxyquire('../lib/github.js', {
         './graphql.js': graphql
       });
-      const res = await github.fetchRepoPage('WICG');
+      const res = await toArray(github.listRepos('WICG'));
       assert(graphql.calledOnce);
       assert.deepStrictEqual(res, [{
         owner: {login: 'WICG'},
@@ -53,22 +57,18 @@ describe('github', () => {
       graphql.onCall(0).resolves({
         organization: {
           repositories: {
-            edges: [
+            nodes: [
               {
-                node: {
-                  owner: {login: 'WICG'},
-                  name: 'mock-repo-1',
-                  labels: {
-                    edges: [
-                      {
-                        node: {
-                          name: 'mock-repo-label-1',
-                          color: '123456',
-                        }
-                      }
-                    ],
-                    pageInfo: {hasNextPage: false}
-                  }
+                owner: {login: 'WICG'},
+                name: 'mock-repo-1',
+                labels: {
+                  nodes: [
+                    {
+                      name: 'mock-repo-label-1',
+                      color: '123456',
+                    }
+                  ],
+                  pageInfo: {hasNextPage: false}
                 }
               }
             ],
@@ -79,22 +79,18 @@ describe('github', () => {
       graphql.onCall(1).resolves({
         organization: {
           repositories: {
-            edges: [
+            nodes: [
               {
-                node: {
-                  owner: {login: 'WICG'},
-                  name: 'mock-repo-2',
-                  labels: {
-                    edges: [
-                      {
-                        node: {
-                          name: 'mock-repo-label-2',
-                          color: '789abc',
-                        }
-                      }
-                    ],
-                    pageInfo: {hasNextPage: false}
-                  }
+                owner: {login: 'WICG'},
+                name: 'mock-repo-2',
+                labels: {
+                  nodes: [
+                    {
+                      name: 'mock-repo-label-2',
+                      color: '789abc',
+                    }
+                  ],
+                  pageInfo: {hasNextPage: false}
                 }
               }
             ],
@@ -105,7 +101,7 @@ describe('github', () => {
       const github = proxyquire('../lib/github.js', {
         './graphql.js': graphql
       });
-      const res = await github.fetchRepoPage('WICG');
+      const res = await toArray(github.listRepos('WICG'));
       assert(graphql.calledTwice);
       assert.deepStrictEqual(res, [{
         owner: {login: 'WICG'},
@@ -123,22 +119,18 @@ describe('github', () => {
       graphql.onCall(0).resolves({
         organization: {
           repositories: {
-            edges: [
+            nodes: [
               {
-                node: {
-                  owner: {login: 'WICG'},
-                  name: 'speech-api',
-                  labels: {
-                    edges: [
-                      {
-                        node: {
-                          name: 'mock-label-1',
-                          color: '111111',
-                        }
-                      }
-                    ],
-                    pageInfo: {hasNextPage: true}
-                  }
+                owner: {login: 'WICG'},
+                name: 'speech-api',
+                labels: {
+                  nodes: [
+                    {
+                      name: 'mock-label-1',
+                      color: '111111',
+                    }
+                  ],
+                  pageInfo: {hasNextPage: true}
                 }
               }
             ],
@@ -149,12 +141,10 @@ describe('github', () => {
       graphql.onCall(1).resolves({
         repository: {
           labels: {
-            edges: [
+            nodes: [
               {
-                node: {
-                  name: 'mock-label-2',
-                  color: '222222',
-                }
+                name: 'mock-label-2',
+                color: '222222',
               }
             ],
             pageInfo: {hasNextPage: true}
@@ -164,12 +154,10 @@ describe('github', () => {
       graphql.onCall(2).resolves({
         repository: {
           labels: {
-            edges: [
+            nodes: [
               {
-                node: {
-                  name: 'mock-label-3',
-                  color: '333333',
-                }
+                name: 'mock-label-3',
+                color: '333333',
               }
             ],
             pageInfo: {hasNextPage: false}
@@ -179,7 +167,7 @@ describe('github', () => {
       const github = proxyquire('../lib/github.js', {
         './graphql.js': graphql
       });
-      const res = await github.fetchRepoPage('WICG');
+      const res = await toArray(github.listRepos('WICG'));
       assert(graphql.calledThrice);
       assert.deepStrictEqual(res, [{
         owner: {login: 'WICG'},
@@ -208,7 +196,7 @@ describe('github', () => {
       }
     }
     const github = proxyquire('../lib/github.js', {'octokat': Stubkat});
-    const hooks = await github.fetchRepoHooks('foo', 'bar');
+    const hooks = await github.listRepoHooks('foo', 'bar');
     assert.deepEqual(hooks, ['mock-hook']);
   });
 

--- a/test/graphql.js
+++ b/test/graphql.js
@@ -4,92 +4,47 @@
 
 const assert = require('assert');
 const proxyquire = require('proxyquire');
-const sinon = require('sinon');
 
-const GH_API = 'https://api.github.com/graphql';
+// Rather than mocking out the whole @octokit/graphql dependency its internal
+// fetch is replaced, see ttps://github.com/octokit/graphql.js/#writing-tests
+const graphql = proxyquire('../lib/graphql.js', {
+  '../config.json': {ghToken: 'mock-token'},
+});
 
 describe('graphql', () => {
-  const mockConfig = {ghToken: 'mock-token'};
-
   it('happy path', async () => {
-    const fakeFetch = sinon.fake.resolves({
-      async json() {
-        return {data: 'mock response'}
+    const res = await graphql('mock query', {
+      request: {
+        fetch: async (url, options) => {
+          assert.equal(options.headers.authorization, 'token mock-token');
+          assert.equal(options.body, '{"query":"mock query"}');
+          return {
+            headers: new Map([['content-type', 'application/json']]),
+            async json() {
+              return {data: 'mock response'};
+            }
+          }
+        }
       }
     });
-    const graphql = proxyquire('../lib/graphql.js', {
-      '../config.json': mockConfig,
-      'node-fetch': fakeFetch,
-    });
-    const res = await graphql('mock query');
     assert.equal(res, 'mock response');
-    assert(fakeFetch.calledOnce);
-    const args = fakeFetch.args[0];
-    assert.equal(args[0], GH_API);
-    assert.equal(args[1].method, 'POST');
-    assert.equal(args[1].headers['Authorization'], 'bearer mock-token');
-    assert.equal(args[1].body, '{"query":"mock query"}');
   });
 
-  it('API error', async () => {
-    const fakeFetch = sinon.fake.resolves({
-      async json() {
-        return {errors: [{message: 'API error'}]}
+  it('error path', async () => {
+    await assert.rejects(graphql('mock query', {
+      request: {
+        fetch: async () => {
+          return {
+            headers: new Map([['content-type', 'application/json']]),
+            async json() {
+              return {errors: [{message: 'mock error'}]};
+            }
+          }
+        }
       }
-    });
-    const graphql = proxyquire('../lib/graphql.js', {
-      '../config.json': mockConfig,
-      'node-fetch': fakeFetch,
-    });
-    await assert.rejects(graphql('mock query'), {
-      name: 'Error',
-      message: 'API error'
+    }), {
+      name: 'GraphqlError',
+      message: 'mock error'
     });
   });
-
-  it('multiple API errors', async () => {
-    const mockErrors = [
-      {message: 'message 1', type: 'type 1'},
-      {message: 'message 2', type: 'type 2'},
-    ];
-    const fakeFetch = sinon.fake.resolves({
-      async json() {
-        return {errors: mockErrors}
-      }
-    });
-    const graphql = proxyquire('../lib/graphql.js', {
-      '../config.json': mockConfig,
-      'node-fetch': fakeFetch,
-    });
-    let err;
-    try {
-      await graphql('mock query');
-    } catch (e) {
-      err = e;
-    }
-    assert(err, 'no error thrown');
-    assert.strictEqual(err.message, 'message 1');
-    assert.strictEqual(err.type, 'type 1');
-    assert.deepStrictEqual(err.all, mockErrors);
-  });
-
-  it('fetch error', async () => {
-    const fakeFetch = sinon.fake.resolves({
-      type: 'error',
-      status: 500,
-      ok: false,
-      async json() {
-        return {data: 'valid response'}
-      }
-    });
-    const graphql = proxyquire('../lib/graphql.js', {
-      '../config.json': mockConfig,
-      'node-fetch': fakeFetch,
-    });
-    // fetch error isn't handled and if the response is JSON it's used.
-    const res = await graphql('mock query');
-    assert.equal(res, 'valid response');
-  });
-
-  afterEach(() => sinon.restore());
 });


### PR DESCRIPTION
Automatic throttling and retries should make this more reliable, and
failing queries are no longer caught and logged and instead allowed to
be fatal.

The use of GraphQL variables for cursor makes some of the pagination
code a bit more straightforward.

All queries are serialized, but by requesting 100 labels the overall
time is about the same as this avoid a lot of extra label queries.

Also normalize the indentation of the GraphQL query blocks.