### PR TITLE
Remove the TODO to always include `hasRecTrack` in report.json

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -81,8 +81,7 @@ async function validate() {
       groupRepos[gid].push({
         name: r.name,
         fullName: fullName(r),
-        // Only include `hasRecTrack` in report.json if it's true. This is
-        // simply to match the original structure. TODO: include if false.
+        // Only include `hasRecTrack` in report.json if it's true.
         hasRecTrack: hasRecTrack ? true : undefined,
       });
     }


### PR DESCRIPTION
Per https://github.com/w3c/validate-repos/pull/81#discussion_r358212606