### PR TITLE
Fix 'labels are sorted' broken on master

### DIFF
--- a/test/github.js
+++ b/test/github.js
@@ -134,7 +134,7 @@ describe('github', () => {
         }
       });
       const github = proxyquire('../lib/github.js', {
-        './graphql.js': graphql
+        './octokit.js': {graphql}
       });
       const repo = (await github.listRepos('WICG').next()).value;
       assert(graphql.calledOnce);


### PR DESCRIPTION
Broken by the combination of these two PRs:
https://github.com/w3c/validate-repos/pull/80
https://github.com/w3c/validate-repos/pull/82