### PR TITLE
Validate job: use access token provided by GitHub

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,7 +22,7 @@ jobs:
         node-version: 12.x
     - name: Setup dependencies
       run: |
-        echo '{"w3capikey":"${{ secrets.W3C_API_KEY }}","ghToken":"${{ secrets.W3C_GITHUB_TOKEN }}"}' > config.json
+        echo '{"w3capikey":"${{ secrets.W3C_API_KEY }}","ghToken":"${{ secrets.GITHUB_TOKEN }}"}' > config.json
         npm ci --production
     - name: Run validate.js
       run: node validate.js > report.json
@@ -40,7 +40,7 @@ jobs:
     - name: Push changes
       if: github.ref == 'refs/heads/main' && github.event.commits[0].author.name != 'w3c-validate-repos-bot'
       run: |
-        git remote set-url --push origin https://x-access-token:${{ secrets.W3C_GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
+        git remote set-url --push origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
         git push origin HEAD:main
     # Run this script last to not interfere with any of the above. The output
     # goes into the logs only for manual inspection when needed.


### PR DESCRIPTION
Via https://github.com/w3c/browser-specs/issues/842

The validate job has been failling since late December 2022. On top of transient API errors, this seems due to WICG having changed settings on the type of access tokens they accept. (Note that the W3C API has been broken in the past couple of days, so latest job failures report a different error)

Job currently uses a personal access token set in a secret. This token no longer works on WICG repositories, as WICG now requires either a fine-grained personal access token or the access token provided by GitHub.

This update makes the job use the access token provided by GitHub.

