### PR TITLE
Add w3c-fedid organization

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -6,7 +6,7 @@ const github = require("./lib/github.js");
 const validator = require("./lib/validator.js");
 const w3cData = require("./lib/w3cData.js");
 
-const orgs = ["w3c", "WebAudio", "immersive-web", "webassembly", "w3ctag", "WICG", "w3cping", "privacycg", "gpuweb", "webmachinelearning"];
+const orgs = ["w3c", "WebAudio", "immersive-web", "webassembly", "w3ctag", "WICG", "w3cping", "privacycg", "gpuweb", "webmachinelearning", "w3c-fedid"];
 const errortypes = [
   "inconsistentgroups",
   "now3cjson",


### PR DESCRIPTION
The FedID WG uses a separate GitHub organization, `w3c-fedid`, added here to the list of tracked organizations.

(There's also a `fedid` for the CG. Not added here as that seems less needed)

Via https://github.com/w3c/browser-specs/pull/1486. First Public Working Draft of FedCM wasn't reported by our find-specs script.
